### PR TITLE
Debug console improvements

### DIFF
--- a/Transcendence/Transcendence.h
+++ b/Transcendence/Transcendence.h
@@ -827,7 +827,8 @@ class CCommandLineDisplay
 		void Input (const CString &sInput);
 		void InputBackspace (void);
 		void InputEnter (void);
-		void InputLastLine (void);
+		void InputHistoryUp(void);
+		void InputHistoryDown(void);
 		void OnKeyDown (int iVirtKey, DWORD dwKeyState);
 		void Output (const CString &sOutput, CG32bitPixel rgbColor = CG32bitPixel::Null());
 		void Paint (CG32bitImage &Dest);
@@ -843,6 +844,9 @@ class CCommandLineDisplay
 		const CString &GetOutput (int iLine);
 		CG32bitPixel GetOutputColor (int iLine);
 		int GetOutputCount (void);
+		void AppendHistory(const CString &sLine);
+		const CString &GetHistory(int iLine);
+		int GetHistoryCount(void);
 		void Update (void);
 
 		CTranscendenceWnd *m_pTrans;
@@ -854,7 +858,11 @@ class CCommandLineDisplay
 		int m_iOutputStart;
 		int m_iOutputEnd;
 		CString m_sInput;
-		CString m_sLastLine;
+		CString m_History[MAX_LINES + 1];
+		int m_iHistoryStart;
+		int m_iHistoryEnd;
+		int m_iHistoryIndex;
+
 
 		CG32bitImage m_Buffer;
 		bool m_bInvalid;

--- a/Transcendence/Transcendence.h
+++ b/Transcendence/Transcendence.h
@@ -819,13 +819,14 @@ class CCommandLineDisplay
 		~CCommandLineDisplay (void);
 
 		void CleanUp (void);
-		inline void ClearInput (void) { m_sInput = NULL_STR; m_bInvalid = true; }
+		inline void ClearInput (void) { m_sInput = NULL_STR; m_iCursorPos = 0; m_bInvalid = true; }
 		inline const CString &GetInput (void) { return m_sInput; }
 		inline int GetOutputLineCount (void) { return GetOutputCount(); }
 		inline const RECT &GetRect (void) { return m_rcRect; }
 		ALERROR Init (CTranscendenceWnd *pTrans, const RECT &rcRect);
 		void Input (const CString &sInput);
 		void InputBackspace (void);
+		void InputDelete (void);
 		void InputEnter (void);
 		void InputHistoryUp(void);
 		void InputHistoryDown(void);
@@ -862,6 +863,7 @@ class CCommandLineDisplay
 		int m_iHistoryStart;
 		int m_iHistoryEnd;
 		int m_iHistoryIndex;
+		int m_iCursorPos;
 
 
 		CG32bitImage m_Buffer;


### PR DESCRIPTION
This adds a few improvements to the in game debug console: a history buffer storing the last 80 input lines, and the cursor can also be moved left/right allowing characters to inserted/deleted in the line rather than just added to the end. Adds support for left, right, down, home, end, and delete keys