### PR TITLE
Debug console improvements part 2

### DIFF
--- a/Transcendence/CCommandLineDisplay.cpp
+++ b/Transcendence/CCommandLineDisplay.cpp
@@ -234,7 +234,11 @@ void CCommandLineDisplay::AutoCompleteSearch(void)
 		m_sHint = NULL_STR;
 
 	if (!sHelp.IsBlank())
-		Output(sHelp, HINT_COLOR);
+		{
+		if (!m_sHint.IsBlank())
+			m_sHint.Append(CONSTLIT("\n"));
+		m_sHint.Append(sHelp);
+		}
 	}
 
 ALERROR CCommandLineDisplay::Init (CTranscendenceWnd *pTrans, const RECT &rcRect)
@@ -575,8 +579,12 @@ void CCommandLineDisplay::Update (void)
 
 	//	Figure out how many lines we need for the hint
 
-	int iHintCols = (m_sHint.IsBlank()) ? 0 : m_sHint.GetLength() + 1;
-	int iHintLines = (iHintCols / iCols) + ((iHintCols % iCols) ? 1 : 0);
+	TArray<CString> HintLines;
+	m_pFonts->Console.BreakText(m_sHint,
+			(RectWidth(m_rcRect) - (LEFT_SPACING + RIGHT_SPACING)),
+			&HintLines);
+
+	int iHintLines = HintLines.GetCount();
 
 	//	Figure out how many lines in the output
 
@@ -615,17 +623,12 @@ void CCommandLineDisplay::Update (void)
 
 	//	Paint the hint line
 
-	iRemainder = iHintCols % iCols;
-	iRemainderText = (iRemainder == 0 ? iCols : iRemainder) - 1;
-
-	iStart = m_sHint.GetLength() - iRemainderText;
-	while (y >= yMin && iStart >= 0)
+	while (y >= yMin && iHintLines > 0)
 		{
-		CString sLine(m_sHint.GetASCIIZPointer() + iStart, iRemainderText);
-		m_Buffer.DrawText(x, y, m_pFonts->Console, HINT_COLOR, sLine);
+		m_Buffer.DrawText(x, y, m_pFonts->Console, HINT_COLOR, HintLines[iHintLines - 1]);
+
 		y -= cyLine;
-		iStart -= iCols;
-		iRemainderText = iCols;
+		iHintLines--;
 		}
 
 	//	Paint each line of output

--- a/Transcendence/Transcendence.h
+++ b/Transcendence/Transcendence.h
@@ -823,6 +823,7 @@ class CCommandLineDisplay
 
 		void CleanUp (void);
 		inline void ClearInput (void) { m_sInput = NULL_STR; m_iCursorPos = 0; m_bInvalid = true; }
+		inline void ClearHint (void) { m_sHint = NULL_STR; m_bInvalid = true; }
 		inline const CString &GetInput (void) { return m_sInput; }
 		inline int GetOutputLineCount (void) { return GetOutputCount(); }
 		inline const RECT &GetRect (void) { return m_rcRect; }
@@ -865,6 +866,7 @@ class CCommandLineDisplay
 		int m_iOutputEnd;
 		CString m_sInput;
 		CString m_History[MAX_LINES + 1];
+		CString m_sHint;
 		int m_iHistoryStart;
 		int m_iHistoryEnd;
 		int m_iHistoryIndex;

--- a/Transcendence/Transcendence.h
+++ b/Transcendence/Transcendence.h
@@ -852,6 +852,8 @@ class CCommandLineDisplay
 		const CString &GetHistory(int iLine);
 		int GetHistoryCount(void);
 		void Update (void);
+		const CString GetCurrentCmd (void);
+		void AutoCompleteSearch (void);
 
 		CTranscendenceWnd *m_pTrans;
 		const SFontTable *m_pFonts;


### PR DESCRIPTION
This adds autocompletion / hints when the tab key is pressed. It searches the global symbol list for matches with the current command then:
* If multiple matches are found it lists them and completes the current command to the longest common stem (e.g. x + tab -> xml)
* If a single match is found we autocomplete to that command
* If the have a single match AND it was already complete then display the output of (help 'command)

The code may need a bit of improvement - I don't know enough about the internals to know the 'right' way to access this data. But it seems to work.