### PR TITLE
rpgChar: Fix using lastShipClass to create ship

### DIFF
--- a/TransCore/RPGCharacters.xml
+++ b/TransCore/RPGCharacters.xml
@@ -333,10 +333,10 @@
 
 						(not objID)
  							(block Nil
-								(setq shipObj (sysCreateShip shipClassUNID pos (typGetStaticData charType 'Sovereign)))
+								(setq shipObj (sysCreateShip shipClassValue pos (typGetStaticData charType 'Sovereign)))
 								(objSetProperty shipObj 'known (@ options 'setKnown))
 								(typSetData charType 'lastNodeID (sysGetNode))
-								(typSetData charType 'lastShipClass shipClassUNID)
+								(typSetData charType 'lastShipClass shipClassValue)
 								(typSetData charType shipIDVar (objGetId shipObj))
 								(typSetData charType 'screenData Nil)
 								
@@ -350,10 +350,10 @@
 							(block Nil
 								(printTo 'log "ERROR: Unable to find object ID: " objID ".")
 								
-								(setq shipObj (sysCreateShip shipClassUNID pos (typGetStaticData charType 'Sovereign)))
+								(setq shipObj (sysCreateShip shipClassValue pos (typGetStaticData charType 'Sovereign)))
 								(objSetProperty shipObj 'known (@ options 'setKnown))
 								(typSetData charType 'lastNodeID (sysGetNode))
-								(typSetData charType 'lastShipClass shipClassUNID)
+								(typSetData charType 'lastShipClass shipClassValue)
 								(typSetData charType shipIDVar (objGetId shipObj))
 								(typSetData charType 'screenData Nil)
 								
@@ -389,7 +389,7 @@
 
 								(if (not shipObj)
 									(block Nil
-										(setq shipObj (sysCreateShip shipClassUNID pos (typGetStaticData charType 'Sovereign)))
+										(setq shipObj (sysCreateShip shipClassValue pos (typGetStaticData charType 'Sovereign)))
 										(typSetData charType shipIDVar (objGetID shipObj))
 										)
 									)
@@ -397,7 +397,7 @@
 								;	Remember where we are
 									
 								(typSetData charType 'lastNodeID (sysGetNode))
-								(typSetData charType 'lastShipClass shipClassUNID)
+								(typSetData charType 'lastShipClass shipClassValue)
 								
 								;	Set known
 								


### PR DESCRIPTION
If rpgCharacterCreateShip is called without a shipClassUNID argument it will attempt to use lastShipClass data stored in the character UNID. This correctly creates/descends the ship the first time it is called, but it then changes lastShipClass to Nil so the characted can not be correctly ascended.  i.e. it will work the first time it is called, but not the second time.

This PR fixes this by saving shipClassValue to lastShipClass