### PR TITLE
RPG Analyzer

### DIFF
--- a/TransCore/RPGAnalyzers.xml
+++ b/TransCore/RPGAnalyzers.xml
@@ -23,21 +23,20 @@
 			>
 
 		<OnScreenInit>
-			(if (scrIsFirstOnInit gScreen)
-				(scrSetData gScreen 'analyzer gItem)
-				)
+			(scrSetData gScreen 'analyzer gItem)
 		</OnScreenInit>
 
-		<Display type="customItemPicker">
+		<Display type="itemPicker"
+				dataFrom=	"player"
+				list=		"*"
+				>
 			<OnDisplayInit>
-				;	Cache the item list in a customPicker so we aren't affected
-				;	by external updates to the item list (e.g. nanofac etc.)
-				(filter (objGetItems gSource "*") theItem
+				(scrSetListFilter gScreen (lambda (theItem)
 					(or
 						(not (itmIsKnown theItem))
 						(objFireItemEvent gSource theItem 'GetIsAnalysisRequired)
 						)
-					)
+					))
 			</OnDisplayInit>
 		</Display>
 
@@ -52,15 +51,6 @@
 						canAnalyze result
 						)
 						
-						;	If we have previously displayed an analysis
-						;	result, then restore the old cursor position
-						(if (scrGetData gScreen 'result)
-							(block Nil
-								(scrSetData gScreen 'result Nil)
-								(scrSetListCursor gScreen (scrGetData gScreen 'cursor))
-								)
-							)
-
 						;	Init skill level
 						(if (not skillLevel)
 							(block Nil
@@ -150,14 +140,13 @@
 							;	Done
 
 							(scrSetData gScreen 'result (@ result 'desc))
-							(scrShowPane gScreen "Done")
+							(scrShowPane gScreen 'Done)
 							)
 					</Action>
 
 					<Action id="actionCancel" cancel="1">
 						(scrExitScreen gScreen)
 					</Action>
-
 				</Actions>
 			</Default>
 
@@ -184,7 +173,20 @@
 
 				<Actions>
 					<Action id="actionContinue" default="1">
-						(scrRefreshScreen gScreen)
+						(block Nil
+							;	Reset filter to show all items again
+							(scrSetListFilter gScreen (lambda (theItem)
+								(or
+									(not (itmIsKnown theItem))
+									(objFireItemEvent gSource theItem 'GetIsAnalysisRequired)
+									)
+								))
+							
+							;	Restore cursor position
+							(scrSetListCursor gScreen (scrGetData gScreen 'cursor))
+							
+							(scrShowPane gScreen 'Default)
+							)
 					</Action>
 
 					<Action id="actionDone" cancel="1">
@@ -192,7 +194,6 @@
 					</Action>
 				</Actions>
 			</Done>
-
 		</Panes>
 
 		<Language>

--- a/TransCore/RPGAnalyzers.xml
+++ b/TransCore/RPGAnalyzers.xml
@@ -23,11 +23,15 @@
 			>
 
 		<OnScreenInit>
-			(scrSetData gScreen 'analyzer gItem)
+			(if (scrIsFirstOnInit gScreen)
+				(scrSetData gScreen 'analyzer gItem)
+				)
 		</OnScreenInit>
 
 		<Display type="customItemPicker">
 			<OnDisplayInit>
+				;	Cache the item list in a customPicker so we aren't affected
+				;	by external updates to the item list (e.g. nanofac etc.)
 				(filter (objGetItems gSource "*") theItem
 					(or
 						(not (itmIsKnown theItem))
@@ -48,6 +52,15 @@
 						canAnalyze result
 						)
 						
+						;	If we have previously displayed an analysis
+						;	result, then restore the old cursor position
+						(if (scrGetData gScreen 'result)
+							(block Nil
+								(scrSetData gScreen 'result Nil)
+								(scrSetListCursor gScreen (scrGetData gScreen 'cursor))
+								)
+							)
+
 						;	Init skill level
 						(if (not skillLevel)
 							(block Nil
@@ -65,10 +78,6 @@
 						
 						(setq canAnalyze Nil)
 						(switch
-							;	Have we already analyzed an item
-							(setq result (scrGetData gScreen 'result))
-								(scrSetDesc gScreen result)
-
 							;	If no more charges then we cannot analyze anything
 							
 							(eq chargesLeft 0)
@@ -107,23 +116,7 @@
 							)
 						
 						;	Initialize actions
-
-						(if (scrGetData gScreen 'result)
-							(block Nil
-								(scrShowAction gScreen 'actionAnalyze Nil)
-								(scrShowAction gScreen 'actionCancel Nil)
-								(scrShowAction gScreen 'actionContinue True)
-								(scrShowAction gScreen 'actionDone True)
-								(scrEnableAction gScreen 'actionContinue (gr chargesLeft 0))
-								)
-							(block Nil
-								(scrShowAction gScreen 'actionAnalyze True)
-								(scrShowAction gScreen 'actionCancel True)
-								(scrShowAction gScreen 'actionContinue Nil)
-								(scrShowAction gScreen 'actionDone Nil)
-								(scrEnableAction gScreen 'actionAnalyze canAnalyze)
-								)
-							)
+						(scrEnableAction gScreen 'actionAnalyze canAnalyze)
 						)
 				</OnPaneInit>
 
@@ -142,8 +135,8 @@
 							(setq analyzerItem (objSetItemProperty gSource analyzerItem 'incCharges -1))
 							(scrSetData gScreen 'analyzer analyzerItem)
 							
-							;	Save the result
-							(scrSetData gScreen 'result (@ result 'desc))
+							;	Save the cursor
+							(scrSetData gScreen 'cursor (scrGetListCursor gScreen))
 							
 							;	Set the filter so we only select the modified item
 							(scrSetListFilter gScreen (lambda (theItem)
@@ -153,7 +146,11 @@
 									(itmIsEqual theItem (@ result 'modifiedItem))
 									)
 								))
-							(scrShowPane gScreen 'Default)
+							
+							;	Done
+
+							(scrSetData gScreen 'result (@ result 'desc))
+							(scrShowPane gScreen "Done")
 							)
 					</Action>
 
@@ -161,28 +158,41 @@
 						(scrExitScreen gScreen)
 					</Action>
 
-					<Action id="actionContinue" default="1">
-						(block Nil
-							;	Clear last result
-							(scrSetData gScreen 'result Nil)
+				</Actions>
+			</Default>
 
-							;	Reset filter to show all items again
-							(scrSetListFilter gScreen (lambda (theItem)
-								(or
-									(not (itmIsKnown theItem))
-									(objFireItemEvent gSource theItem 'GetIsAnalysisRequired)
-									)
-								))
+			<Done noListNavigation="true">
+				<OnPaneInit>
+					(block (
+						(analyzerItem (scrGetData gScreen 'analyzer))
+						(chargesLeft (itmGetProperty analyzerItem 'charges))
+						)
 
-							(scrShowPane gScreen 'Default)
+						;	Report the number of charges remaining
+						(scrSetControlValue gScreen 'chargesLeft
+							(scrTranslate gScreen 'descChargesLeft { charges:chargesLeft })
 							)
+
+						(scrSetDesc gScreen (scrGetData gScreen 'result))
+						(scrEnableAction gScreen 'actionContinue (gr chargesLeft 0))
+						)
+				</OnPaneInit>
+
+				<Controls>
+					<Text id="chargesLeft"/>
+				</Controls>
+
+				<Actions>
+					<Action id="actionContinue" default="1">
+						(scrRefreshScreen gScreen)
 					</Action>
 
 					<Action id="actionDone" cancel="1">
 						(scrExitScreen gScreen)
 					</Action>
 				</Actions>
-			</Default>
+			</Done>
+
 		</Panes>
 
 		<Language>

--- a/TransCore/RPGAnalyzers.xml
+++ b/TransCore/RPGAnalyzers.xml
@@ -19,29 +19,39 @@
 -->
 
 	<DockScreen UNID="&dsRPGAnalyzeItem;"
-			type=				"itemPicker"
+			inherit=			"&dsDockScreenBase;"
 			>
 
-		<ListOptions
-			dataFrom=	"player"
-			list=		"*"
-			>
-			(scrSetListFilter gScreen (lambda (theItem)
-				(or
-					(not (itmIsKnown theItem))
-					(objFireItemEvent gSource theItem 'GetIsAnalysisRequired)
-					)
-				))
-		</ListOptions>
-			
+		<OnInit>
+			(scrSetData gScreen 'analyzer gItem)
+		</OnInit>
+
+		<Display type="itemPicker"
+				dataFrom=	"player"
+				list=		"*"
+				>
+			<OnDisplayInit>
+				(scrSetListFilter gScreen (lambda (theItem)
+					(or
+						(not (itmIsKnown theItem))
+						(objFireItemEvent gSource theItem 'GetIsAnalysisRequired)
+						)
+					))
+			</OnDisplayInit>
+		</Display>
+
 		<Panes>
 			<Default>
 				<OnPaneInit>
-					(block (desc skillLevel chargesLeft itemToAnalyze canAnalyze result)
-					
-						;	Init skill level
+					(block (
+						(analyzerItem (scrGetData gScreen 'analyzer))
+						(skillLevel (typGetData &dsRPGAnalyzeItem; 'skillLevel))
+						(chargesLeft (itmGetProperty analyzerItem 'charges))
+						(itemToAnalyze (scrGetItem gScreen))
+						canAnalyze result
+						)
 						
-						(setq skillLevel (typGetData &dsRPGAnalyzeItem; 'skillLevel))
+						;	Init skill level
 						(if (not skillLevel)
 							(block Nil
 								(typSetData &dsRPGAnalyzeItem; 'skillLevel 0)
@@ -50,94 +60,94 @@
 							)
 							
 						;	Report the number of charges remaining
-
-						(setq chargesLeft (itmGetProperty gItem 'charges))
-						(setq desc (cat
-							"Charges Left: " chargesLeft "\n\n"
-							))
-						
-						;	Item to analyze
-							
-						(setq itemToAnalyze (scrGetItem gScreen))
+						(scrSetControlValue gScreen 'chargesLeft
+							(scrTranslate gScreen 'descChargesLeft { charges:chargesLeft })
+							)
 						
 						;	Continue with description
 						
 						(setq canAnalyze Nil)
 						(switch
+							;	Have we already analyzed an item
+							(setq result (scrGetData gScreen 'result))
+								(scrSetDesc gScreen result)
+
 							;	If no more charges then we cannot analyze anything
 							
 							(eq chargesLeft 0)
-								(setq desc (cat desc "Unfortunately, " (itmGetName gItem 0x40) " is out of charge and cannot function."))
+								(scrSetDescTranslate gScreen 'descNoCharges { name:(itmGetName analyzerItem 0x40) })
 								
 							;	Nothing to analyze
 							
 							(not itemToAnalyze)
-								(setq desc (cat desc "There are no items here requiring analysis."))
+								(scrSetDescTranslate gScreen 'descNoCharges)
 								
 							;	Check to see if this analyzer can handle this item
 							
-							(and (setq result (objFireItemEvent gSource gItem 'CanAnalyzeItem { itemToAnalyze: itemToAnalyze }))
+							(and (setq result (objFireItemEvent gSource analyzerItem 'CanAnalyzeItem { itemToAnalyze: itemToAnalyze }))
 									(not (@ result 'canAnalyzeItem))
 									)
-								(setq desc (cat desc (@ result 'message)))
+								(scrSetDesc gScreen (@ result 'message))
 								
 							;	OK
 							
 							(block Nil
-								(setq desc (cat desc
-									"You can analyze " (itmGetName itemToAnalyze 0x804)
-									))
-									
 								(switch
 									(ls skillLevel 2)
-										(setq desc (cat desc
-											", though you do not have much experience analyzing items."
-											))
+										(scrSetDescTranslate gScreen 'descAnalyze1 { name:(itmGetName itemToAnalyze 0x804) })
 									
 									(ls skillLevel 5)
-										(setq desc (cat desc
-											"; you have some experience analyzing items."
-											))
+										(scrSetDescTranslate gScreen 'descAnalyze2 { name:(itmGetName itemToAnalyze 0x804) })
 									
 									(ls skillLevel 10)
-										(setq desc (cat desc
-											"; you are proficient at analyzing items."
-											))
+										(scrSetDescTranslate gScreen 'descAnalyze3 { name:(itmGetName itemToAnalyze 0x804) })
 									
-									(setq desc (cat desc
-										"; you are an expert at analyzing items."
-										))
+									(scrSetDescTranslate gScreen 'descAnalyze4 { name:(itmGetName itemToAnalyze 0x804) })
 									)
 								
 								(setq canAnalyze True)
 								)
 							)
 						
-						;	Initialize
-						
-						(scrSetDesc gScreen desc)
-						(scrEnableAction gScreen 0 canAnalyze)
+						;	Initialize actions
+
+						(if (scrGetData gScreen 'result)
+							(block Nil
+								(scrShowAction gScreen 'actionAnalyze Nil)
+								(scrShowAction gScreen 'actionCancel Nil)
+								(scrShowAction gScreen 'actionContinue True)
+								(scrShowAction gScreen 'actionDone True)
+								(scrEnableAction gScreen 'actionContinue (gr chargesLeft 0))
+								)
+							(block Nil
+								(scrShowAction gScreen 'actionAnalyze True)
+								(scrShowAction gScreen 'actionCancel True)
+								(scrShowAction gScreen 'actionContinue Nil)
+								(scrShowAction gScreen 'actionDone Nil)
+								(scrEnableAction gScreen 'actionAnalyze canAnalyze)
+								)
+							)
 						)
 				</OnPaneInit>
 
+				<Controls>
+					<Text id="chargesLeft"/>
+				</Controls>
+
 				<Actions>
-					<Action name="Analyze Item" key="A" default="1">
-						(block (result)
-						
-							;	Analyze the item
-							(setq result (rpgAnalyzeItem gSource (scrGetItem gScreen)))
+					<Action id="actionAnalyze" default="1">
+						(block (
+							(analyzerItem (scrGetData gScreen 'analyzer))
+							(result (rpgAnalyzeItem gSource (scrGetItem gScreen)))
+							)
 						
 							;	Consume a charge on the analyzer
-							(setq gItem (objSetItemProperty gSource gItem 'incCharges -1))
+							(setq analyzerItem (objSetItemProperty gSource analyzerItem 'incCharges -1))
+							(scrSetData gScreen 'analyzer analyzerItem)
 							
-							;	Set the title (for the next pane)
-							(setq gTitle (cat 
-								"Charges Left: " (itmGetProperty gItem 'charges) "\n\n"
-								(@ result 'desc)
-								))
-								
-							;(dbgOutput "Analyze:")
-								
+							;	Save the result
+							(scrSetData gScreen 'result (@ result 'desc))
+							
 							;	Set the filter so we only select the modified item
 							(scrSetListFilter gScreen (lambda (theItem)
 								(block Nil
@@ -146,32 +156,61 @@
 									(itmIsEqual theItem (@ result 'modifiedItem))
 									)
 								))
-							
-							;	Done
-							
-							(scrShowPane gScreen "Done")
+							(scrShowPane gScreen 'Default)
 							)
 					</Action>
 
-					<Action name="Cancel" cancel="1" key="C">
-						<Exit/>
+					<Action id="actionCancel" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
-					
+
+					<Action id="actionContinue" default="1">
+						(block Nil
+							;	Clear last result
+							(scrSetData gScreen 'result Nil)
+
+							;	Reset filter to show all items again
+							(scrSetListFilter gScreen (lambda (theItem)
+								(or
+									(not (itmIsKnown theItem))
+									(objFireItemEvent gSource theItem 'GetIsAnalysisRequired)
+									)
+								))
+
+							(scrShowPane gScreen 'Default)
+							)
+					</Action>
+
+					<Action id="actionDone" cancel="1">
+						(scrExitScreen gScreen)
+					</Action>
 				</Actions>
 			</Default>
-			
-			<Done 
-					desc="=gTitle"
-					noListNavigation="true"
-					>
-
-				<Actions>
-					<Action name="Done" cancel="1" default="1" key="D">
-						<Exit/>
-					</Action>
-				</Actions>
-			</Done>
 		</Panes>
+
+		<Language>
+			<Text id="actionAnalyze">[A]nalyze Item</Text>
+
+			<Text id="descChargesLeft">Charges Left: %charges%</Text>
+			<Text id="descNoCharges">
+				Unfortunately, %name% is out of charge and cannot function.
+			</Text>
+			<Text id="descNoItemsHere">
+				There are no items here requiring analysis.
+			</Text>
+			<Text id="descAnalyze1">
+				You can analyze %name%, though you do not have much experience analyzing items.
+			</Text>
+			<Text id="descAnalyze2">
+				You can analyze %name%; you have some experience analyzing items.
+			</Text>
+			<Text id="descAnalyze3">
+				You can analyze %name%; you are proficient at analyzing items.
+			</Text>
+			<Text id="descAnalyze4">
+				You can analyze %name%; you are an expert at analyzing items.
+			</Text>
+		</Language>
 	</DockScreen>
 
 <!-- GLOBAL FUNCTIONS ==========================================================

--- a/TransCore/RPGAnalyzers.xml
+++ b/TransCore/RPGAnalyzers.xml
@@ -22,21 +22,18 @@
 			inherit=			"&dsDockScreenBase;"
 			>
 
-		<OnInit>
+		<OnScreenInit>
 			(scrSetData gScreen 'analyzer gItem)
-		</OnInit>
+		</OnScreenInit>
 
-		<Display type="itemPicker"
-				dataFrom=	"player"
-				list=		"*"
-				>
+		<Display type="customItemPicker">
 			<OnDisplayInit>
-				(scrSetListFilter gScreen (lambda (theItem)
+				(filter (objGetItems gSource "*") theItem
 					(or
 						(not (itmIsKnown theItem))
 						(objFireItemEvent gSource theItem 'GetIsAnalysisRequired)
 						)
-					))
+					)
 			</OnDisplayInit>
 		</Display>
 
@@ -80,7 +77,7 @@
 							;	Nothing to analyze
 							
 							(not itemToAnalyze)
-								(scrSetDescTranslate gScreen 'descNoCharges)
+								(scrSetDescTranslate gScreen 'descNoItemsHere)
 								
 							;	Check to see if this analyzer can handle this item
 							


### PR DESCRIPTION
This is a fix for [Thermo shell nanofac causes UI issues](https://ministry.kronosaur.com/record.hexm?id=71787) affecting analyzers.

When the nanofac OnUpdate event is called the dsRPGAnalyzeItem item list gets reset (see also [60413](https://ministry.kronosaur.com/record.hexm?id=60413)) and the `gItem` variable is changed to the nanofac causing various glitches as the dockscreen tries to use the nanofac to analyze items.

This PR saves the analyzer item as screen data which solves most of the UI problems (~~apart from reseting to the start of the list~~). Switching to a customItemPicker fixes the list reset

