### PR TITLE
Make XML well-formed

### DIFF
--- a/TransCore/CommonwealthFleet.xml
+++ b/TransCore/CommonwealthFleet.xml
@@ -1008,7 +1008,7 @@ PLAYER DATA
 			/>
 
 		<Trade currency="credit" max="100000" replenish="5000">
-			<Sell	criteria="m +commonwealth; +military; -illegal; -notForSale; -notStandard;" priceAdj="100" inventoryAdj="200"levelFrequency="systemLevel:ruc|c|cur"/>
+			<Sell	criteria="m +commonwealth; +military; -illegal; -notForSale; -notStandard;" priceAdj="100" inventoryAdj="200" levelFrequency="systemLevel:ruc|c|cur"/>
 			<Sell	criteria="*NU -Illegal; -ID; -NotForSale;"	priceAdj="100"/>
 			
 			<Refuel			criteria="f +BasicFuel; L:1-9;" priceAdj="90"/>

--- a/TransCore/Dall01.xml
+++ b/TransCore/Dall01.xml
@@ -265,10 +265,10 @@
 		<Image imageID="&rsDallSphere;" imageX="0" imageY="0" imageWidth="96" imageHeight="96"/>
 		
 		<StaticData>
-			<00182001_Donation>
+			<SistersOfDominaDonation>
 				;		attd	rel		text
 				'(Nil	-1		200		"This is a remarkable item! Domina will be very pleased!")
-			</00182001_Donation>
+			</SistersOfDominaDonation>
 		</StaticData>
 		
 		<Events>

--- a/TransCore/Dall01.xml
+++ b/TransCore/Dall01.xml
@@ -265,10 +265,10 @@
 		<Image imageID="&rsDallSphere;" imageX="0" imageY="0" imageWidth="96" imageHeight="96"/>
 		
 		<StaticData>
-			<SistersOfDominaDonation>
+			<Data id="SistersOfDominaDonation">
 				;		attd	rel		text
 				'(Nil	-1		200		"This is a remarkable item! Domina will be very pleased!")
-			</SistersOfDominaDonation>
+			</Data>
 		</StaticData>
 		
 		<Events>

--- a/TransCore/MiscItems.xml
+++ b/TransCore/MiscItems.xml
@@ -545,10 +545,10 @@
 		<Image imageID="&rsItems1;" imageX="288" imageY="0" imageWidth="96" imageHeight="96"/>
 
 		<StaticData>
-			<SistersOfDominaDonation>
+			<Data id="SistersOfDominaDonation">
 				;			attd	rel		text
 				'(Nil		-1		135		"This empty vessel may nevertheless possess a connection to the soul it once housed. Domina will use it to gather her flock.")
-			</SistersOfDominaDonation>
+			</Data>
 		</StaticData>
 	</ItemType>
 
@@ -1193,7 +1193,7 @@
 		<Image imageID="&rsItems1;" imageX="192" imageY="96" imageWidth="96" imageHeight="96"/>
 
 		<StaticData>
-			<SistersOfDominaDonation>
+			<Data id="SistersOfDominaDonation">
 				;				attd	rel
 				(list	Nil		0		0
 
@@ -1206,7 +1206,7 @@
 						"We thank you for your good intentions; may Domina be with you. Always."
 						))
 					)
-			</SistersOfDominaDonation>
+			</Data>
 		</StaticData>
 	</ItemType>
 

--- a/TransCore/MiscItems.xml
+++ b/TransCore/MiscItems.xml
@@ -545,10 +545,10 @@
 		<Image imageID="&rsItems1;" imageX="288" imageY="0" imageWidth="96" imageHeight="96"/>
 
 		<StaticData>
-			<00182001_Donation>
+			<SistersOfDominaDonation>
 				;			attd	rel		text
 				'(Nil		-1		135		"This empty vessel may nevertheless possess a connection to the soul it once housed. Domina will use it to gather her flock.")
-			</00182001_Donation>
+			</SistersOfDominaDonation>
 		</StaticData>
 	</ItemType>
 
@@ -1193,7 +1193,7 @@
 		<Image imageID="&rsItems1;" imageX="192" imageY="96" imageWidth="96" imageHeight="96"/>
 
 		<StaticData>
-			<00182001_Donation>
+			<SistersOfDominaDonation>
 				;				attd	rel
 				(list	Nil		0		0
 
@@ -1206,7 +1206,7 @@
 						"We thank you for your good intentions; may Domina be with you. Always."
 						))
 					)
-			</00182001_Donation>
+			</SistersOfDominaDonation>
 		</StaticData>
 	</ItemType>
 

--- a/TransCore/SistersOfDomina.xml
+++ b/TransCore/SistersOfDomina.xml
@@ -1344,7 +1344,7 @@
 					
 						;	First check to see if the item itself has a donation entry
 						
-						(setq entry (eval (itmGetStaticData theItem "00182001_Donation")))
+						(setq entry (eval (itmGetStaticData theItem "SistersOfDominaDonation")))
 							entry
 						
 						;	If the item doesn't tell us anything then look for an entry


### PR DESCRIPTION
In order for TransGenesis to work, it needs to be able to read Transcendence's XML code. However, Java's StAX parser for XML is picky about formatting; it kept giving me unavoidable failures because a few lines of XML were not "well-formed" according to the rules. One rule is that an XML tag must start with a letter (this rule was broken by the Domina donation code on the Dall Sphere). Another detail is that that one element in CommonwealthFleet.xml had two attributes that were improperly spaced. Only four minor edits are needed in order to make the game XML meet the minimum formatting requirements.