### PR TITLE
Item use framework / new dockscreens

### DIFF
--- a/TransCore/CentauriWarlords.xml
+++ b/TransCore/CentauriWarlords.xml
@@ -135,6 +135,7 @@
 	<!-- Barrel of Centauri Nanos -->
 
 	<ItemType UNID="&itCentauriNanos;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"[barrel(s) of ]Centauri nanos"
 			level=				"3"
 			value=				"250"
@@ -146,13 +147,30 @@
 
 			description=		"These nanomachines weave a diamond matrix through the target material. Armor that has been treated in this way will be more resistant to laser and impact damage."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"centauriNanos"
 
 			sortName=			"Centauri nanos, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancementTable">
+				(
+					{	criteria:"a &lt;=3"	enhancement:0x0808	}
+					{	criteria:"a &lt;=5"	enhancement:0x0805	}
+					{	criteria:"a &lt;=6"	enhancement:0x0803	}
+					{	criteria:"a &gt;10"	enhancement:Nil	descID:'TooAdvanced	}
+					)
+			</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The coating is composed of nanomachines that strengthen your armor against laser and impact damage.
+			</Text>
+		</Language>
 	</ItemType>
 	
 <!-- SHIP CLASSES -->

--- a/TransCore/RPGLibrary.xml
+++ b/TransCore/RPGLibrary.xml
@@ -79,6 +79,11 @@
 	<!ENTITY dsRPGCommoditiesExchangeSell	"0x00010034">
 	<!ENTITY dsRPGShipBroker			"0x00010035">
 	<!ENTITY dsRPGWingmanEncounter		"0x00010036">
+	<!ENTITY dsRPGUseItem				"0x00010037">
+	<!ENTITY dsRPGUseItemBase			"0x00010038">
+	<!ENTITY dsRPGUseItemOnArmor		"0x00010039">
+	<!ENTITY dsRPGUseItemOnDevice		"0x0001003A">
+	<!ENTITY dsRPGUseItemOnCargo		"0x0001003B">
 	
 	<!-- 0040-004F CARGO CRATE -->
 	
@@ -102,6 +107,7 @@
 	<!-- 00B0-00CF ITEMS -->
 
 	<!ENTITY baStdAuxMountDeviceBase	"0x000100B0">
+	<!ENTITY baStdArmorRepair			"0x000100B1">
 
 	<!-- 00D0-00EF WINGMEN -->
 
@@ -142,6 +148,7 @@
 	<Module filename="RPGShipBroker.xml"/>
 	<Module filename="RPGShipScreens.xml"/>
 	<Module filename="RPGTypes.xml"/>
+	<Module filename="RPGUsefulItems.xml"/>
 	<Module filename="RPGWingmen.xml"/>
 
 </CoreLibrary>

--- a/TransCore/RPGLibrary.xml
+++ b/TransCore/RPGLibrary.xml
@@ -108,6 +108,7 @@
 
 	<!ENTITY baStdAuxMountDeviceBase	"0x000100B0">
 	<!ENTITY baStdArmorRepair			"0x000100B1">
+	<!ENTITY baStdPasteBarrel			"0x000100B2">
 
 	<!-- 00D0-00EF WINGMEN -->
 

--- a/TransCore/RPGShipScreens.xml
+++ b/TransCore/RPGShipScreens.xml
@@ -113,6 +113,13 @@
 			<Default>
 				<OnPaneInit>
 					(block (thisItem maxCount)
+						(if (scrGetData gScreen 'cursor)
+							(block Nil
+								(scrSetListCursor gScreen (scrGetData gScreen 'cursor))
+								(scrSetData gScreen 'cursor Nil)
+								)
+							)
+
 						(setq thisItem (scrGetItem gScreen))
 						(setq maxCount (itmGetCount thisItem))
 
@@ -137,6 +144,7 @@
 
 						;	Enable/disable actions
 						(scrEnableAction gScreen 'actionJettisonItem (gr maxCount 0))
+						(scrEnableAction gScreen 'actionUse (or (itmMatches thisItem 'u) (itmHasAttribute thisItem 'Usable)))
 						)
 				</OnPaneInit>
 
@@ -161,6 +169,15 @@
 									(scrShowPane gScreen "Default")
 									)
 								)
+							)
+					</Action>
+
+					<Action id="actionUse" default="1">
+						(block Nil
+							(scrSetData gScreen 'cursor (scrGetListCursor gScreen))
+							(scrShowScreen gScreen &dsRPGUseItem; {
+								useItem: (scrGetItem gScreen)
+								})
 							)
 					</Action>
 
@@ -221,6 +238,7 @@
 		<Language>
 			<Text id="actionJettisonItem">[J]ettison this Item</Text>
 			<Text id="actionJettison">[J]ettison</Text>
+			<Text id="actionUse">[U]se this Item</Text>
 
 			<Text id="descCargoEmpty">You are in your ship's cargo hold.</Text>
 			<Text id="descCargoItem">Unit mass: %unitMass%</Text>

--- a/TransCore/RPGShipScreens.xml
+++ b/TransCore/RPGShipScreens.xml
@@ -100,6 +100,7 @@
 			name=				"Ship's Cargo Hold"
 			desc=				"Interior of Ship"
 			type=				"itemPicker"
+			inherit=			"&dsDockScreenBase;"
 			nestedScreen=		"true"
 			>
 
@@ -109,89 +110,99 @@
 			/>
 
 		<Panes>
-			<Default
-					desc=	"You are in your ship's cargo hold.">
-
+			<Default>
 				<OnPaneInit>
-					(block (thisItem desc)
+					(block (thisItem maxCount)
 						(setq thisItem (scrGetItem gScreen))
+						(setq maxCount (itmGetCount thisItem))
+
 						(switch
 							(not thisItem)
-								(setq gMaxCount 0)
+								(scrSetDescTranslate gScreen 'descCargoEmpty)
 
-							(itmIsInstalled thisItem)
-								(setq gMaxCount 0)
+							(= maxCount 1)
+								(scrSetDescTranslate gScreen 'descCargoItem {
+									unitMass: (strMassString (itmGetMass thisItem))
+									})
 
-							(setq gMaxCount (itmGetCount thisItem))
+							(scrSetDescTranslate gScreen 'descCargoItems {
+								unitMass: (strMassString (itmGetMass thisItem))
+								count: maxCount
+								totalMass: (strMassString (* (itmGetMass thisItem) maxCount))
+								})
 							)
 
-						(if thisItem
-							(block Nil
-								(setq desc (cat "Unit mass: " (strMassString (itmGetMass thisItem))))
-								(if (gr gMaxCount 1)
-									(setq desc (cat desc " (" gMaxCount " at " (strMassString (multiply (itmGetMass thisItem) gMaxCount)) ")"))
-									)
-								(scrSetDesc gScreen desc)
-								)
-							)
+						;	Remember some calculations for later
+						(scrSetData gScreen 'maxCount maxCount)
 
-						; Enable/disable actions
-						(scrEnableAction gScreen 0 (gr gMaxCount 0))
+						;	Enable/disable actions
+						(scrEnableAction gScreen 'actionJettisonItem (gr maxCount 0))
 						)
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="Jettison this Item" key="J" >
-						(switch
-							(gr gMaxCount 1)
-								(scrShowPane gScreen "JettisonQuantity")
+					<Action id="actionJettisonItem">
+						(block (
+							(maxCount (scrGetData gScreen 'maxCount))
+							)
+							(switch
+								(gr maxCount 1)
+									(scrShowPane gScreen "JettisonQuantity")
 
-							(eq gMaxCount 1)
 								(block (itemsToJettison)
-									; Create cargo crate
+									;	Create cargo crate
 									(if (not gDest)
 										(setq gDest (sysCreateStation &stGenericCargoCrate; (sysVectorPolarOffset gPlayerShip 0 0)))
 										)
 
-									; Dump items
+									;	Dump items
 									(setq itemsToJettison (scrRemoveItem gScreen 1))
 									(rpgJettisonItem gDest itemsToJettison)
 									(scrShowPane gScreen "Default")
 									)
+								)
 							)
 					</Action>
 
-					<Action name="Done" cancel="1" key="D">
+					<Action id="actionDone" cancel="1">
 						<Exit/>
 					</Action>
-
 				</Actions>
-
 			</Default>
 
 			<JettisonQuantity
 					showCounter=	"true">
 
 				<OnPaneInit>
-					(block Nil
-						(scrSetDesc gScreen (cat "How many items do you wish to jettison?"))
-						(scrSetCounter gScreen gMaxCount)
+					(block (
+						(maxCount (scrGetData gScreen 'maxCount))
+						)
+						(scrSetDescTranslate gScreen 'descHowMany)
+						(scrSetCounter gScreen maxCount)
 						)
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="Jettison" default="1" key="J">
-						(block (count)
-							(setq count (scrGetCounter gScreen))
-							(if (gr count gMaxCount)
-								(scrSetCounter gScreen gMaxCount)
+					<Action id="actionJettison" default="1">
+						(block (
+							(useCount (scrGetCounter gScreen))
+							(maxCount (scrGetData gScreen 'maxCount))
+							)
+
+							(switch
+								(= useCount 0)
+									(scrShowPane gScreen "Default")
+
+								(gr useCount maxCount)
+									(scrSetCounter gScreen maxCount)
+
 								(block (itemsToJettison)
-									; Create cargo crate
+									;	Create cargo crate
 									(if (not gDest)
 										(setq gDest (sysCreateStation &stGenericCargoCrate; (sysVectorPolarOffset gPlayerShip 0 0)))
 										)
 
-									; Dump items
+									;	Dump items
 									(setq itemsToJettison (scrRemoveItem gScreen count))
 									(rpgJettisonItem gDest itemsToJettison)
 									(scrShowPane gScreen "Default")
@@ -200,15 +211,22 @@
 							)
 					</Action>
 
-					<Action name="Cancel" cancel="1" key="C">
-						<ShowPane pane="Default"/>
+					<Action id="actionCancel" cancel="1">
+						(scrShowPane gScreen "Default")
 					</Action>
-
 				</Actions>
-
 			</JettisonQuantity>
 		</Panes>
 
+		<Language>
+			<Text id="actionJettisonItem">[J]ettison this Item</Text>
+			<Text id="actionJettison">[J]ettison</Text>
+
+			<Text id="descCargoEmpty">You are in your ship's cargo hold.</Text>
+			<Text id="descCargoItem">Unit mass: %unitMass%</Text>
+			<Text id="descCargoItems">Unit mass: %unitMass% (%count% at %totalMass%)</Text>
+			<Text id="descHowMany">How many items do you wish to jettison?</Text>
+		</Language>
 	</DockScreen>
 
 	<!-- Refuel ship screen -->

--- a/TransCore/RPGUsefulItems.xml
+++ b/TransCore/RPGUsefulItems.xml
@@ -400,9 +400,23 @@
 
 <!-- BASE CLASSES -->
 
+	<!-- Armor Repair Item Base Class
+
+	Armor repair items should inherit from this class. Typically they should
+	set useScreen to dsRPGUseItemOnArmor.
+
+	EVENTS
+		CanRepairItem - override this event to limit which types of armor can be repaired
+
+	STATIC DATA
+		RepairHP - number of HP repaired in a typical use of this item
+
+    -->
 
 	<Type UNID="&baStdArmorRepair;">
 		<Events>
+			<CanRepairItem>True</CanRepairItem>
+
 			<CanUseOnItem>
 				(block (
 					(dstItem (@ gData 'itemToUseOn))

--- a/TransCore/RPGUsefulItems.xml
+++ b/TransCore/RPGUsefulItems.xml
@@ -628,6 +628,102 @@
 		</Language>
 	</Type>
 
+	<!-- Paste Barrel Item Base Class
+
+	Armor coating barrels should inherit from this class. Typically they should
+	set useScreen to dsRPGUseItemOnArmor.
+
+	STATIC DATA
+		enhancement - enhancement to apply to armor
+		enhancementTable - table of criteria and enhancements for different armor types / levels
+
+    -->
+
+	<Type UNID="&baStdPasteBarrel;">
+		<Events>
+			<CanUseOnItem>
+				(block (
+					(dstItem (@ gData 'itemToUseOn))
+					)
+					(switch
+						(not (itmMatches dstItem "a"))
+							Nil
+
+						(itmIsKnown gItem)
+							{
+								canUse: True
+								desc: (itmTranslate gItem 'descUsageOK {
+									useItem: (itmGetName gItem)
+									dstItem: (itmGetName dstItem 'demonstrative)
+									})
+								}
+						{
+							canUse: True
+							desc: (itmTranslate gItem 'descUsageUnknown {
+								useItem: (itmGetName gItem)
+								dstItem: (itmGetName dstItem 'demonstrative)
+								})
+							}
+						)
+					)
+			</CanUseOnItem>
+
+			<OnUseOnItem>
+				(block (
+					(dstItem (@ gData 'itemToUseOn))
+					(enhancement (itmGetStaticData gItem 'enhancement))
+					(enhancementTable (itmGetStaticData gItem 'enhancementTable))
+					enhancementInfo
+					)
+					;	Search the enhancementTable for first matching entry
+					(enumWhile enhancementTable (not enhancementInfo) theEntry
+						(if (and (@ theEntry 'criteria) (itmMatches dstItem (@ theEntry 'criteria)))
+							(setq enhancementInfo theEntry)
+							))
+
+					;	General enhancement has higher priority than table
+					(if enhancement (set@ enhancementInfo 'enhancement enhancement))
+
+					(switch
+						(not (itmMatches dstItem "aI"))
+							"only installed armor for now"
+
+						(not enhancementInfo)
+							"ERROR: not implemented yet"
+
+						(block (result)
+							;	Apply enhancement
+							(setq result (shpEnhanceItem gPlayerShip dstItem (@ enhancementInfo 'enhancement)))
+
+							;	Remove the armor paste from the player's cargo
+							(objRemoveItem gPlayerShip gItem 1)
+
+							;	Identify the item
+							(itmSetKnown gItem)
+
+							{
+								desc: (cat
+									(itmTranslate gItem 'descResultIntro)
+									(intArmorEnhanceStatus result)
+									(if (@ enhancementInfo 'descID) " ")
+									(itmTranslate gItem (cat "descResult" (@ enhancementInfo 'descID)))
+									)
+								}
+							)
+						)
+					)
+			</OnUseOnItem>
+		</Events>
+
+		<Language>
+			<Text id="descUsageOK">You can use the %useItem% on %dstItem%.</Text>
+			<Text id="descUsageUnknown">The barrel seems to contain some kind of armor paste. You can use it on %dstItem%.</Text>
+
+			<Text id="descResultTooAdvanced">Unfortunately, your armor is too strong for the nanomachines.</Text>
+			<Text id="descResultTooPrimitive">Unfortunately, your armor is too primitive for the nanomachines.</Text>
+		</Language>
+	</Type>
+
 <!-- CODE -->
 
 	<Globals>

--- a/TransCore/RPGUsefulItems.xml
+++ b/TransCore/RPGUsefulItems.xml
@@ -1,0 +1,628 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<TranscendenceModule>
+	
+<!-- RPG USE ITEM ==============================================================
+
+	This screen allows the player to use an item on another item or device.
+
+	gData uses the following fields:
+
+		useItem:	The item being used. If not specifed we check gItem instead
+
+-->
+
+	<DockScreen UNID="&dsRPGUseItem;"
+			inherit=			"&dsDockScreenBase;"
+			nestedScreen=		"true"
+			name=				"=(itmGetName (or (@ gData 'useItem) gItem) 'capitalize)"
+			>
+
+		<OnScreenInit>
+			(scrSetData gScreen 'useItem (or (@ gData 'useItem) gItem))
+		</OnScreenInit>
+
+		<Panes>
+			<Default>
+				<OnPaneInit>
+					(block (
+						(useItem (scrGetData gScreen 'useItem))
+						(theShip gPlayerShip)
+
+						(screenSet (list
+							{
+								screen: &dsRPGUseItem;
+								label: (scrTranslate gScreen 'screenSetUseItem)
+								mainScreen: True
+								}
+							{
+								screen: &dsRPGUseItemOnArmor;
+								label: (scrTranslate gScreen 'screenSetUseItemOnArmor)
+								data: { useItem: useItem }
+								}
+							{
+								screen: &dsRPGUseItemOnDevice;
+								label: (scrTranslate gScreen 'screenSetUseItemOnDevice)
+								data: { useItem: useItem }
+								}
+							{
+								screen: &dsRPGUseItemOnCargo;
+								label: (scrTranslate gScreen 'screenSetUseItemOnCargo)
+								data: { useItem: useItem }
+								}
+							))
+						)
+
+						(scrSetControlValue gScreen 'useItem {
+							source: theShip
+							item: useItem
+							})
+
+						(scrSetDescTranslate gScreen 'descUseItem)
+
+						;   Define the screen set
+						(scrSetData gScreen 'screenSet screenSet)
+						(rpgInitScreenSet screenSet)
+						)
+				</OnPaneInit>
+
+				<Controls>
+					<ItemDisplay id="useItem"/>
+				</Controls>
+
+				<Actions>
+					<Action id="actionArmor">
+						(scrShowScreen gScreen &dsRPGUseItemOnArmor; {
+							useItem: (scrGetData gScreen 'useItem)
+							screenSet: (scrGetData gScreen 'screenSet)
+							})
+					</Action>
+					<Action id="actionDevice">
+						(scrShowScreen gScreen &dsRPGUseItemOnDevice; {
+							useItem: (scrGetData gScreen 'useItem)
+							screenSet: (scrGetData gScreen 'screenSet)
+							})
+					</Action>
+					<Action id="actionCargo">
+						(scrShowScreen gScreen &dsRPGUseItemOnCargo; {
+							useItem: (scrGetData gScreen 'useItem)
+							screenSet: (scrGetData gScreen 'screenSet)
+							})
+					</Action>
+				</Actions>
+			</Default>
+		</Panes>
+
+		<Language>
+			<Text id="actionArmor">Use on [A]rmor</Text>
+			<Text id="actionDevice">Use on D[e]vice</Text>
+			<Text id="actionCargo">Use on [C]argo item</Text>
+
+			<Text id="descUseItem">How do you want to use this item?</Text>
+
+			<Text id="screenSetUseItem">Main page</Text>
+			<Text id="screenSetUseItemOnArmor">Armor page</Text>
+			<Text id="screenSetUseItemOnDevice">Device page</Text>
+			<Text id="screenSetUseItemOnCargo">Cargo page</Text>
+		</Language>
+	</DockScreen>
+
+<!-- RPG USE ITEM ON ARMOR =====================================================
+
+	This screen allows the player to use an item on an armor segment.
+
+	gData uses the following fields:
+
+		useItem:	The item being used. If not specifed we check gItem instead
+
+		screenSet:	An RPG Screen Set structure (if we've been called from the
+					primary use item screen
+
+-->
+
+	<DockScreen UNID="&dsRPGUseItemOnArmor;"
+			inherit=			"&dsRPGUseItemBase;"
+			nestedScreen=		"true"
+			>
+
+		<Display type="armorSelector"
+				dataFrom=	"player"
+				list=		"aI"
+				noEmptySlots="true"
+				/>
+
+		<Panes>
+		</Panes>
+
+		<Language>
+			<Text id="actionUse">[U]se on this Armor Segment</Text>
+		</Language>
+	</DockScreen>
+
+<!-- RPG USE ITEM ON DEVICE ====================================================
+
+	This screen allows the player to use an item on an installed device.
+
+	gData uses the following fields:
+
+		useItem:	The item being used. If not specifed we check gItem instead
+
+		screenSet:	An RPG Screen Set structure (if we've been called from the
+					primary use item screen
+
+-->
+
+	<DockScreen UNID="&dsRPGUseItemOnDevice;"
+			inherit=			"&dsRPGUseItemBase;"
+			nestedScreen=		"true"
+			>
+
+		<Display type="deviceSelector"
+				dataFrom=	"player"
+				list=		"dI"
+				noEmptySlots="true"
+				/>
+
+		<Panes>
+		</Panes>
+
+		<Language>
+			<Text id="actionUse">[U]se on this Device</Text>
+		</Language>
+	</DockScreen>
+
+<!-- RPG USE ITEM ON CARGO =====================================================
+
+	This screen allows the player to use an item on an item in the cargo bay.
+
+	gData uses the following fields:
+
+		useItem:	The item being used. If not specifed we check gItem instead
+
+		screenSet:	An RPG Screen Set structure (if we've been called from the
+					primary use item screen
+
+-->
+
+	<DockScreen UNID="&dsRPGUseItemOnCargo;"
+			inherit=			"&dsRPGUseItemBase;"
+			nestedScreen=		"true"
+			>
+
+		<Display type="itemPicker"
+				dataFrom=	"player"
+				list=		"*U"
+				>
+			<OnDisplayInit>
+				(block (
+					(useItem (scrGetData gScreen 'useItem))
+					)
+					(scrAddListFilter gScreen 'filterAll "All" (lambda (theItem)
+							(and (itmMatches theItem "*U") (not (itmIsEqual theItem useItem)))
+							))
+					(scrAddListFilter gScreen 'filterInstallable "Devices &amp; Armor" (lambda (theItem)
+							(and (itmMatches theItem "adUN") (not (itmIsEqual theItem useItem)))
+							))
+					(scrAddListFilter gScreen 'filterInstallable "Damaged Items" (lambda (theItem)
+							(and (itmMatches theItem "adUD") (not (itmIsEqual theItem useItem)))
+							))
+					(scrAddListFilter gScreen 'filterGeneral "General" (lambda (theItem)
+							(and (itmMatches theItem "*~admU") (not (itmIsEqual theItem useItem)))
+							))
+					(scrAddListFilter gScreen 'filterAmmo "Ammo" (lambda (theItem)
+							(and (itmMatches theItem "mU") (not (itmIsEqual theItem useItem)))
+							))
+
+					;	Do not need to reproduce details shown in itemPicker list
+					(scrSetData gScreen 'hideCurrent True)
+					)
+			</OnDisplayInit>
+		</Display>
+
+		<Panes>
+		</Panes>
+
+		<Language>
+		</Language>
+	</DockScreen>
+
+<!-- RPG USE ITEM BASE =========================================================
+
+	Base class for the various Use Item on XYZ dockscreens.
+
+	gData uses the following fields:
+
+		useItem:	The item being used. If not specifed we check gItem instead
+
+		screenSet:	An RPG Screen Set structure (if we've been called from the
+					primary use item screen
+
+-->
+
+	<DockScreen UNID="&dsRPGUseItemBase;"
+			inherit=			"&dsDockScreenBase;"
+			nestedScreen=		"true"
+			name=				"=(itmGetName (or (@ gData 'useItem) gItem) 'capitalize)"
+			>
+
+		<OnScreenInit>
+			(scrSetData gScreen 'useItem (or (@ gData 'useItem) gItem 1))
+		</OnScreenInit>
+
+		<Panes>
+			<Default>
+				<OnPaneInit>
+					(block (
+						(useItem (scrGetData gScreen 'useItem))
+						(theShip gPlayerShip)
+						(dstItem (scrGetItem gScreen))
+						(useInfo (itmFireEvent useItem 'CanUseOnItem {
+								itemToUseOn: dstItem
+								shipObj: theShip
+								} ))
+						)
+
+						;	Set the description
+						(scrSetControlValue gScreen 'useItem {
+							title: (itmGetName useItem 'capitalize)
+							desc: (itmGetProperty useItem 'description)
+							})
+
+						(if (not (scrGetData gScreen 'hideCurrent))
+							(scrSetControlValue gScreen 'currentItem {
+								source: theShip
+								item: dstItem
+								})
+							)
+
+						(switch
+							(@ useInfo 'desc)
+								(scrSetDesc gScreen (@ useInfo 'desc))
+
+							(not dstItem)
+								(scrSetDescTranslate gScreen 'descNoItemsHere)
+
+							(scrSetDescTranslate gScreen 'descCanNotUse {
+								useItem: (itmGetName useItem 'article)
+								dstItem: (itmGetName dstItem 'article)
+								})
+							)
+						(scrEnableAction gScreen 'actionUse (@ useInfo 'canUse))
+
+						(rpgInitScreenSet (@ gData 'screenSet))
+						)
+				</OnPaneInit>
+
+				<Controls>
+					<ItemDisplay id="useItem"/>
+					<ItemDisplay id="currentItem"/>
+				</Controls>
+
+				<Actions>
+					<Action id="actionUse" default="1">
+						(block (
+							(useItem (scrGetData gScreen 'useItem))
+							(theShip gPlayerShip)
+							(dstItem (scrGetItem gScreen))
+							(theCursor (scrGetListCursor gScreen))
+							result
+							)
+							;	Use the item
+							(setq result (itmFireEvent useItem 'OnUseOnItem {
+								itemToUseOn: dstItem
+								shipObj: theShip
+								}))
+
+							;	Restore the cursor position
+							(scrSetListCursor gScreen theCursor)
+
+							;	Store result and display it
+							(scrSetData gScreen 'usageResult result)
+							(scrShowPane gScreen 'ShowResult)
+							)
+					</Action>
+				</Actions>
+			</Default>
+
+			<ShowResult noListNavigation="true">
+				<OnPaneInit>
+					(block (
+						(useItem (scrGetData gScreen 'useItem))
+						(dstItem (scrGetItem gScreen))
+						(theShip gPlayerShip)
+						(result (scrGetData gScreen 'usageResult))
+						)
+						(scrSetControlValue gScreen 'useItem {
+							title: (itmGetName useItem 'capitalize)
+							desc: (itmGetProperty useItem 'description)
+							})
+
+						(if (not (scrGetData gScreen 'hideCurrent))
+							(scrSetControlValue gScreen 'currentItem {
+								source: theShip
+								item: dstItem
+								})
+							)
+
+						(scrSetDesc gScreen (@ result 'desc))
+
+						(if (and (objHasItem theShip useItem 1) (not (@ result 'nextScreen)))
+							(scrShowAction gScreen 'actionDone Nil)
+							(scrShowAction gScreen 'actionContinue Nil)
+							)
+						)
+				</OnPaneInit>
+
+				<Controls>
+					<ItemDisplay id="useItem"/>
+					<ItemDisplay id="currentItem"/>
+				</Controls>
+
+				<Actions>
+					<Action id="actionContinue" default="1" cancel="1">
+						(scrShowPane gScreen 'Default)
+					</Action>
+					<Action id="actionDone" default="1" cancel="1">
+						(block (
+							(result (scrGetData gScreen 'usageResult))
+							)
+							(if (@ gData 'screenSet)
+								(scrExitScreen gScreen)
+								)
+							(switch
+								(= (@ result 'nextScreen) 'forceUndock)
+									(scrExitScreen gScreen 'forceUndock)
+
+								(= (@ result 'nextScreen) 'forceExit)
+									(scrExitScreen gScreen)
+
+								(@ result 'nextScreen)
+									(block Nil
+										(scrExitScreen gScreen)
+										(scrShowScreen gScreen (@ result 'nextScreen) (@ result 'nextScreenData))
+										)
+
+								(scrExitScreen gScreen)
+								)
+							)
+					</Action>
+				</Actions>
+			</ShowResult>
+		</Panes>
+
+		<Language>
+			<Text id="actionUse">[U]se on this Item</Text>
+
+			<Text id="descCanNotUse">You cannot use %useItem% on %dstItem%.</Text>
+		</Language>
+	</DockScreen>
+
+
+<!-- BASE CLASSES -->
+
+
+	<Type UNID="&baStdArmorRepair;">
+		<Events>
+			<CanUseOnItem>
+				(block (
+					(dstItem (@ gData 'itemToUseOn))
+					(shipObj (@ gData 'shipObj))
+					(armorNoun (cat (objGetArmorName shipObj dstItem) " " (itmGetName dstItem 'noModifiers)))
+					(skillLevel (typGetData &baStdArmorRepair; 'skillLevel))
+					(skillDesc (switch
+						(ls skillLevel 2)	(itmTranslate gItem 'descUsageExperience1)
+						(ls skillLevel 5)	(itmTranslate gItem 'descUsageExperience2)
+						(ls skillLevel 10)	(itmTranslate gItem 'descUsageExperience3)
+											(itmTranslate gItem 'descUsageExperience4)
+						))
+					)
+					(switch
+						;	Armor repair items only work on armor
+						(not (itmMatches dstItem "a"))
+							{
+								canUse: Nil
+								desc: (itmTranslate gItem 'descUsageNotArmor {
+									useItem: (itmGetName gItem 'plural)
+									dstItem: (itmGetName dstItem 'article)
+									})
+								}
+
+						;	Disallow uninstalled armor as it does not record HP
+						(not (itmIsInstalled dstItem))
+							{
+								canUse: Nil
+								desc: (itmTranslate gItem 'descUsageInstalledOnly {
+									useItem: (itmGetName gItem)
+									dstItem: (itmGetName dstItem 'article)
+									})
+								}
+
+						;	Item is unidentified (assume it is a barrel for now)
+						(not (itmIsKnown gItem))
+							{
+								canUse: True
+								desc: (itmTranslate gItem 'descUsageUnknown {
+									useItem: (itmGetName gItem)
+									dstItem: (itmGetName dstItem 'demonstrative)
+									})
+								}
+
+						;	Armor segment is not damaged
+						(= (objGetArmorDamage shipObj dstItem) 0)
+							{
+								canUse: Nil
+								desc: (itmTranslate gItem 'descUsageArmorNotDamaged {
+									useItem: (itmGetName gItem)
+									dstItem: (itmGetName dstItem)
+									armorNoun: armorNoun
+									})
+								}
+
+						;	Check if we can repair armor with the given item
+						(not (and (setq aItemToRepair dstItem)
+								(objFireItemEvent shipObj gItem 'CanRepairItem)
+								))
+							{
+								canUse: Nil
+								desc: (itmTranslate gItem 'descUsageCanNotRepair {
+									useItem: (itmGetName gItem)
+									dstItem: (itmGetName dstItem)
+									})
+								}
+
+						;	Otherwise OK
+						{
+							canUse: True
+							desc: (itmTranslate gItem 'descUsageOK {
+								useItem: (itmGetName gItem 'article)
+								dstItem: (itmGetName dstItem)
+								experience: skillDesc
+								})
+							}
+						)
+					)
+			</CanUseOnItem>
+
+			<OnUseOnItem>
+				(block (
+					(dstItem (@ gData 'itemToUseOn))
+					(shipObj (@ gData 'shipObj))
+					(repair (eval (itmGetStaticData gItem 'RepairHP)))
+					(descIntro (itmTranslate gItem 'descResultIntro))
+					status hpRepaired
+					)
+
+					(switch
+						(not (itmMatches dstItem "a"))
+							(setq status 'NotArmor)
+
+						(= (objGetArmorDamage shipObj dstItem) 0)
+							(setq status 'NotDamaged)
+
+						(not repair)
+							(setq status 'ItemError)
+
+						(block (
+							(armorSeg (itmGetArmorInstalledLocation dstItem))
+							(skillLevel (typGetData &baStdArmorRepair; 'skillLevel))
+
+							;	As skill level increased, the player's failure chance
+							;	decreases. Also the amount of hp repaired increased.
+							(failureChance (switch
+								(ls skillLevel 2)	20
+								(ls skillLevel 5)	10
+								(ls skillLevel 10)	5
+													0
+								))
+							(repairScale (switch
+								(ls skillLevel 2)	80
+								(ls skillLevel 5)	100
+								(ls skillLevel 10)	110
+									(min (+ 70 (* skillLevel 5)) 200)
+								))
+							(usedUp 100)
+							)
+							;	If the repairing item is damaged armor, then we don't repair as much
+							(if (itmMatches theItem "aD")
+								(setq repair (/ repair 2))
+								)
+
+							;	Scale repair HP with skill level
+							(setq repair (/ (* repair repairScale) 100))
+
+							;	Do the repairs
+							(switch
+								(leq (random 1 100) failureChance)
+									(if (= (random 1 2) 1)
+										;	Sometimes we fail and damage the armor
+										(block Nil
+											(shpDamageArmor shipObj armorSeg 7 (/ (* repair (random 20 100)) 100))
+											(setq status 'DamagedMore)
+											)
+
+										;	Sometimes we fail without damaging further
+										(setq status 'Failed)
+										)
+
+								(block ()
+									(setq hpRepaired (objRepairArmor shipObj dstItem repair))
+									(setq status 'Repaired)
+										
+									;	How much of the kit did we use?
+									(if (gr repair 0)
+										(setq usedUp (/ (* 100 hpRepaired) repair))
+										)
+
+									;	Skill level increases
+									(typIncData &baStdArmorRepair; 'skillLevel)
+									)
+								)
+
+							;	Use up the item
+							(if (or (ls skillLevel 10)
+									(geq usedUp 20)
+									(leq (random 1 100) (add usedUp 20))
+									)
+								(objRemoveItem shipObj gItem 1)
+
+								; Item is not used up
+								(setq status 'Reusable)
+								)
+							)
+						)
+
+					;	Identify the item
+					(itmSetKnown gItem)
+
+					{
+						desc: (cat
+							descIntro (if descIntro " ")
+							(itmTranslate gItem (cat "descResult" status) {
+								useItem: (itmGetName gItem 'demonstrative)
+								hpRepaired: hpRepaired
+								})
+							)
+						}
+					)
+			</OnUseOnItem>
+		</Events>
+
+		<Language>
+			<Text id="descUsageArmorNotDamaged">The ship's %armorNoun% is not damaged.</Text>
+			<Text id="descUsageCanNotRepair">Unfortunately, you cannot repair %dstItem% with %useItem%.</Text>
+			<Text id="descUsageInstalledOnly">%useItem% can only be used on installed armor segments.</Text>
+			<Text id="descUsageNotArmor">%UseItem% are used for repairing armor and will not function on %dstItem%.</Text>
+			<Text id="descUsageOK">You can attempt to repair this %dstItem% with %useItem%; %experience%</Text>
+			<Text id="descUsageUnknown">The barrel seems to contain some kind of armor paste. You can use it on %dstItem%.</Text>
+
+			<Text id="descUsageExperience1">though you do not have much experience repairing armor.</Text>
+			<Text id="descUsageExperience2">you have some experience repairing armor.</Text>
+			<Text id="descUsageExperience3">you are proficient at repairing armor.</Text>
+			<Text id="descUsageExperience4">you are an expert at repairing armor.</Text>
+
+			<Text id="descResultDamagedMore">Unfortunately, your attempt to repair the armor has only damaged it further.</Text>
+			<Text id="descResultFailed">Unfortunately, your attempt to repair the armor was unsuccessful and %useItem% was ruined in the process.</Text>
+			<Text id="descResultItemError">ERROR: &lt;RepairHP&gt; static data not found.</Text>
+			<Text id="descResultNotArmor">That is not an armor segment</Text>
+			<Text id="descResultNotDamaged">That armor segment is not damaged. There is no need to attempt repairs.</Text>
+			<Text id="descResultRepaired">You have successfully repaired %hpRepaired% hit points of damage to your armor.</Text>
+			<Text id="descResultReusable">
+				You have successfully repaired %hpRepaired% hit points of damage to your armor.
+
+				There is still enough of the %useItem% left to repair other segments.
+			</Text>
+		</Language>
+	</Type>
+
+<!-- CODE -->
+
+	<Globals>
+		(block Nil
+			;	Just a wrapper to save some typing
+			(setq itmTranslate (lambda (theItem textID data default)
+				(typTranslate (itmGetType theItem) textID data default)
+				))
+			)
+	</Globals>
+
+</TranscendenceModule>

--- a/TransCore/SungSlavers.xml
+++ b/TransCore/SungSlavers.xml
@@ -118,7 +118,7 @@
 				/>
 
 		<StaticData>
-			<RepairHP>125</RepairHP>
+			<Data id="RepairHP">125</Data>
 		</StaticData>
 
 		<Events>
@@ -283,7 +283,7 @@
 				/>
 
 		<StaticData>
-			<RepairHP>90</RepairHP>
+			<Data id="RepairHP">90</Data>
 		</StaticData>
 
 		<Events>
@@ -387,7 +387,7 @@
 				/>
 
 		<StaticData>
-			<RepairHP>35</RepairHP>
+			<Data id="RepairHP">35</Data>
 		</StaticData>
 
 		<Events>
@@ -436,7 +436,7 @@
 				/>
 
 		<StaticData>
-			<RepairHP>12</RepairHP>
+			<Data id="RepairHP">12</Data>
 		</StaticData>
 		
 		<Events>

--- a/TransCore/SungSlavers.xml
+++ b/TransCore/SungSlavers.xml
@@ -86,6 +86,7 @@
 	<!-- Segment of Dragon Armor -->
 
 	<ItemType UNID="&itDragonArmor;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"[segment(s) of ]Dragon armor"
 			level=				"7"
 			value=				"5000"
@@ -96,7 +97,7 @@
 
 			description=		"This is a heavier version of the Sung's innovative armor, used on its Dragon slavers."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			useUninstalledOnly=	"true"
 
 			sortName=			"Sung armor.10"
@@ -253,6 +254,7 @@
 	<!-- Segment of Heavy Sung Armor -->
 
 	<ItemType UNID="&itHeavySungArmor;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"[segment(s) of ]heavy Sung armor"
 			level=				"6"
 			value=				"2300"
@@ -263,7 +265,7 @@
 
 			description=		"This is a heavier version of the Sung's innovative armor, generally used on its Earth slavers."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			useUninstalledOnly=	"true"
 
 			sortName=			"Sung armor.20"
@@ -354,6 +356,7 @@
 	<!-- Segment of Sung Armor -->
 
 	<ItemType UNID="&itSungArmor;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"[segment(s) of ]Sung armor"
 			level=				"5"
 			value=				"600"
@@ -364,7 +367,7 @@
 
 			description=		"This blast-resistant tiled armor can be cannibalized to repair other Sung armor segments."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			useUninstalledOnly=	"true"
 
 			sortName=			"Sung armor.30"
@@ -403,6 +406,7 @@
 	<!-- Segment of Light Sung Armor -->
 
 	<ItemType UNID="&itLightSungArmor;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"[segment(s) of ]light Sung armor"
 			level=				"2"
 			value=				"60"
@@ -413,7 +417,7 @@
 
 			description=		"The Sung created this blast-resistant tiled armor for their Wind slavers. The tiles can be cannibalized to repair other Sung armor segments."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			useUninstalledOnly=	"true"
 
 			sortName=			"Sung armor.40"

--- a/TransCore/UsefulItems.xml
+++ b/TransCore/UsefulItems.xml
@@ -391,10 +391,6 @@
 		<StaticData>
 			<RepairHP>10</RepairHP>
 		</StaticData>
-		
-		<Events>
-			<CanRepairItem>True</CanRepairItem>
-		</Events>
 	</ItemType>
 
 	<!-- Large Armor Patch -->
@@ -421,10 +417,6 @@
 		<StaticData>
 			<RepairHP>30</RepairHP>
 		</StaticData>
-		
-		<Events>
-			<CanRepairItem>True</CanRepairItem>
-		</Events>
 	</ItemType>
 
 	<!-- Light Armor Repair Kit -->
@@ -451,10 +443,6 @@
 		<StaticData>
 			<RepairHP>70</RepairHP>
 		</StaticData>
-		
-		<Events>
-			<CanRepairItem>True</CanRepairItem>
-		</Events>
 	</ItemType>
 
 	<!-- Medium Armor Repair Kit -->
@@ -481,10 +469,6 @@
 		<StaticData>
 			<RepairHP>120</RepairHP>
 		</StaticData>
-		
-		<Events>
-			<CanRepairItem>True</CanRepairItem>
-		</Events>
 	</ItemType>
 
 	<!-- Heavy Armor Repair Kit -->
@@ -511,10 +495,6 @@
 		<StaticData>
 			<RepairHP>200</RepairHP>
 		</StaticData>
-		
-		<Events>
-			<CanRepairItem>True</CanRepairItem>
-		</Events>
 	</ItemType>
 
 <!-- BARRELS -->
@@ -567,10 +547,6 @@
 		<StaticData>
 			<RepairHP>(rollDice 6 6 0)</RepairHP>
 		</StaticData>
-		
-		<Events>
-			<CanRepairItem>True</CanRepairItem>
-		</Events>
 
 		<Language>
 			<Text id="descResultIntro">The paste is a silicon-based compound that patches damaged sections of your armor.</Text>
@@ -970,10 +946,6 @@
 		<StaticData>
 			<RepairHP>(rollDice 8 12 0)</RepairHP>
 		</StaticData>
-
-		<Events>
-			<CanRepairItem>True</CanRepairItem>
-		</Events>
 
 		<Language>
 			<Text id="descResultIntro">The paste contains a colony of nanomachines that can repair your armor.</Text>

--- a/TransCore/UsefulItems.xml
+++ b/TransCore/UsefulItems.xml
@@ -370,6 +370,7 @@
 	<!-- Small Armor Patch -->
 
 	<ItemType UNID="&itSmallArmorPatch;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"small armor patch(es)"
 			level=				"1"
 			value=				"25"
@@ -380,7 +381,7 @@
 
 			description=		"This is a small armor plate that can be welded to your ship's armor to repair damage."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 
 			sortName=			"armor patch, small"
 			>
@@ -399,6 +400,7 @@
 	<!-- Large Armor Patch -->
 
 	<ItemType UNID="&itLargeArmorPatch;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"large armor patch(es)"
 			level=				"3"
 			value=				"150"
@@ -409,7 +411,7 @@
 
 			description=		"This is a large armor plate that can be welded to your ship's armor to repair damage."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 
 			sortName=			"armor patch, large"
 			>
@@ -428,6 +430,7 @@
 	<!-- Light Armor Repair Kit -->
 
 	<ItemType UNID="&itLightArmorRepair;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"light armor repair kit"
 			level=				"5"
 			value=				"700"
@@ -438,7 +441,7 @@
 
 			description=		"This kit can be used in the field to repair damaged armor. It will repair up to 70 hp of damage."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 
 			sortName=			"armor repair kit, 50"
 			>
@@ -457,6 +460,7 @@
 	<!-- Medium Armor Repair Kit -->
 
 	<ItemType UNID="&itMediumArmorRepair;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"medium armor repair kit"
 			level=				"7"
 			value=				"4000"
@@ -467,7 +471,7 @@
 
 			description=		"This kit can be used in the field to repair damaged armor. It will repair up to 120 hp of damage."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 
 			sortName=			"armor repair kit, 30"
 			>
@@ -486,6 +490,7 @@
 	<!-- Heavy Armor Repair Kit -->
 
 	<ItemType UNID="&itHeavyArmorRepair;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"heavy armor repair kit"
 			level=				"9"
 			value=				"10000"
@@ -496,7 +501,7 @@
 
 			description=		"This kit can be used in the field to repair damaged armor. It will repair up to 200 hp of damage."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 
 			sortName=			"armor repair kit, 10"
 			>
@@ -540,6 +545,7 @@
 	<!-- Barrel of Armor Repair Paste -->
 
 	<ItemType UNID="&itSiliconArmorPatch;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"[barrel(s) of ]armor repair paste"
 			level=				"1"
 			value=				"50"
@@ -551,7 +557,7 @@
 
 			description=		"Apply this paste to an armor segment to repair light to moderate damage."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 
 			sortName=			"armor repair paste, barrel of"
 			>
@@ -559,13 +565,16 @@
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
 		
 		<StaticData>
-			<BarrelDesc>"The paste is a silicon-based compound that patches damaged sections of your armor."</BarrelDesc>
 			<RepairHP>(rollDice 6 6 0)</RepairHP>
 		</StaticData>
 		
 		<Events>
 			<CanRepairItem>True</CanRepairItem>
 		</Events>
+
+		<Language>
+			<Text id="descResultIntro">The paste is a silicon-based compound that patches damaged sections of your armor.</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Carbon-Weaver Nanos -->
@@ -939,6 +948,7 @@
 	<!-- Barrel of Repairing Nanos -->
 
 	<ItemType UNID="&itRepairingNanos;"
+			inherit=			"&baStdArmorRepair;"
 			name=				"[barrel(s) of ]repairing nanos"
 			level=				"3"
 			value=				"260"
@@ -950,7 +960,7 @@
 
 			description=		"Apply this paste to an armor segment to repair moderate to heavy damage."
 
-			useScreen=			"&dsUseArmorPatch;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 
 			sortName=			"repairing nanos, barrel of"
 			>
@@ -958,13 +968,16 @@
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
 		
 		<StaticData>
-			<BarrelDesc>"The paste contains a colony of nanomachines that can repair your armor."</BarrelDesc>
 			<RepairHP>(rollDice 8 12 0)</RepairHP>
 		</StaticData>
 
 		<Events>
 			<CanRepairItem>True</CanRepairItem>
 		</Events>
+
+		<Language>
+			<Text id="descResultIntro">The paste contains a colony of nanomachines that can repair your armor.</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Unknown Barrels -->

--- a/TransCore/UsefulItems.xml
+++ b/TransCore/UsefulItems.xml
@@ -389,7 +389,7 @@
 		<Image imageID="&rsItems1;" imageX="288" imageY="576" imageWidth="96" imageHeight="96"/>
 		
 		<StaticData>
-			<RepairHP>10</RepairHP>
+			<Data id="RepairHP">10</Data>
 		</StaticData>
 	</ItemType>
 
@@ -415,7 +415,7 @@
 		<Image imageID="&rsItems1;" imageX="288" imageY="576" imageWidth="96" imageHeight="96"/>
 
 		<StaticData>
-			<RepairHP>30</RepairHP>
+			<Data id="RepairHP">30</Data>
 		</StaticData>
 	</ItemType>
 
@@ -441,7 +441,7 @@
 		<Image imageID="&rsItems1;" imageX="288" imageY="576" imageWidth="96" imageHeight="96"/>
 
 		<StaticData>
-			<RepairHP>70</RepairHP>
+			<Data id="RepairHP">70</Data>
 		</StaticData>
 	</ItemType>
 
@@ -467,7 +467,7 @@
 		<Image imageID="&rsItems1;" imageX="288" imageY="576" imageWidth="96" imageHeight="96"/>
 
 		<StaticData>
-			<RepairHP>120</RepairHP>
+			<Data id="RepairHP">120</Data>
 		</StaticData>
 	</ItemType>
 
@@ -493,7 +493,7 @@
 		<Image imageID="&rsItems1;" imageX="288" imageY="576" imageWidth="96" imageHeight="96"/>
 
 		<StaticData>
-			<RepairHP>200</RepairHP>
+			<Data id="RepairHP">200</Data>
 		</StaticData>
 	</ItemType>
 
@@ -545,7 +545,7 @@
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
 		
 		<StaticData>
-			<RepairHP>(rollDice 6 6 0)</RepairHP>
+			<Data id="RepairHP">(rollDice 6 6 0)</Data>
 		</StaticData>
 
 		<Language>
@@ -944,7 +944,7 @@
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
 		
 		<StaticData>
-			<RepairHP>(rollDice 8 12 0)</RepairHP>
+			<Data id="RepairHP">(rollDice 8 12 0)</Data>
 		</StaticData>
 
 		<Language>

--- a/TransCore/UsefulItems.xml
+++ b/TransCore/UsefulItems.xml
@@ -502,6 +502,7 @@
 	<!-- Barrel of Ablative Armor Coating -->
 
 	<ItemType UNID="&itAblativeArmorCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]ablative armor coating"
 			level=				"1"
 			value=				"40"
@@ -513,13 +514,23 @@
 
 			description=		"This coating is used to protect a ship's armor against laser and particle beam weapons."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"ablative"
 
 			sortName=			"ablative armor coating, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x0a05</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The paste is an ablative coating that resists laser and particle damage.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Armor Repair Paste -->
@@ -556,6 +567,7 @@
 	<!-- Barrel of Carbon-Weaver Nanos -->
 
 	<ItemType UNID="&itCarbonWeaverNanos;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]carbon-weaver nanos"
 			level=				"2"
 			value=				"80"
@@ -567,18 +579,36 @@
 
 			description=		"The nanomachines in this paste weave a strong carbon grid through a ship's armor. Armor that has been treated in this way will be stronger and more resistant to damage."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"carbon-weave"
 
 			sortName=			"carbon-weaver nanos, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancementTable">
+				(
+					{	criteria:"a &lt;=3"	enhancement:0x0105	}
+					{	criteria:"a &lt;=5"	enhancement:0x0103	}
+					{	criteria:"a &lt;=6"	enhancement:0x0101	}
+					{	criteria:"a &gt;6"	enhancement:Nil	descID:'TooAdvanced	}
+					)
+			</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The coating is composed of nanomachines that strengthen your armor.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Particle Resistance Coating -->
 
 	<ItemType UNID="&itParticleResistCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]particle resistance coating"
 			level=				"3"
 			value=				"100"
@@ -590,18 +620,29 @@
 
 			description=		"This coating is used to protect a ship's armor against particle beam weapons."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"particleresist"
 
 			sortName=			"particle resistance coating, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x0925</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The paste is a coating that resists particle damage.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Radiation Immunity Coating -->
 
 	<ItemType UNID="&itRadiationImmuneCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]anti-radiation coating"
 			level=				"4"
 			value=				"350"
@@ -613,18 +654,29 @@
 
 			description=		"This borocarbide coating absorbs deadly radiation before it can penetrate your ship's hull."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"radiationimmune"
 
 			sortName=			"anti-radiation coating, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x0b00</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The barrel contains a borocarbide paste that resists radiation.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- EMP Immunity Coating -->
 
 	<ItemType UNID="&itEMPImmuneCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]monopole dust"
 			level=				"5"
 			value=				"700"
@@ -636,18 +688,29 @@
 
 			description=		"When applied to armor, monopole dust dissipates EMP energy, rendering it harmless."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"EMPimmune"
 
 			sortName=			"monopole dust, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x0b20</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The barrel contains monopole dust, which protects your armor against EMP effects.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Ion Resistant Coating -->
 
 	<ItemType UNID="&itIonResistCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]ion resistance coating"
 			level=				"6"
 			value=				"1300"
@@ -659,18 +722,29 @@
 
 			description=		"This coating is used to protect a ship's armor against ion damage."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"ionresist"
 
 			sortName=			"ion resistance coating, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x0945</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The paste is a coating that resists ion damage.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Shield Interfering Coating -->
 
 	<ItemType UNID="&itShieldInterfereCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]meteorsteel dust"
 			level=				"6"
 			value=				"200"
@@ -682,18 +756,29 @@
 
 			description=		"Meteorsteel interferes with most kinds of shield generators."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"shieldresist"
 
 			sortName=			"meteorsteel dust, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x8c00</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The barrel contains meteorsteel dust.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Ion Effects Immunity Coating -->
 
 	<ItemType UNID="&itIonEffectImmuneCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]dyon dust"
 			level=				"7"
 			value=				"2800"
@@ -705,18 +790,29 @@
 
 			description=		"Dust activated by dyons immunizes armor against ion effects that disable or damage a ship's systems."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"ioneffectimmune"
 
 			sortName=			"dyon dust, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x0c00</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The barrel contains dyon dust, which immunizes your armor against disabling ion effects.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Thermo Resistant Coating -->
 
 	<ItemType UNID="&itThermoResistCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]ithalium paste"
 			level=				"8"
 			value=				"5250"
@@ -728,18 +824,29 @@
 
 			description=		"This coating is used to protect a ship's armor against thermonuclear damage."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"thermoresist"
 
 			sortName=			"ithalium paste, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x0955</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The paste is a coating that resists thermonuclear damage.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Carbon Weaver 2 Coating -->
 
 	<ItemType UNID="&itCarbonWeaver2Coating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]orthosteel nanos"
 			level=				"9"
 			value=				"9000"
@@ -751,18 +858,35 @@
 
 			description=		"The nanomachines in this paste weave a strong orthosteel grid through a ship's armor. Armor that has been treated in this way will be stronger and more resistant to damage."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"carbon-weave2"
 
 			sortName=			"orthosteel nanos, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancementTable">
+				(
+					{	criteria:"a &lt;=6"	enhancement:Nil	descID:'TooPrimitive	}
+					{	criteria:"a &lt;=10"	enhancement:0x0105	}
+					{	criteria:"a &gt;10"	enhancement:Nil	descID:'TooAdvanced	}
+					)
+			</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The coating is composed of nanomachines that strengthen your armor.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Decon Gel -->
 
 	<ItemType UNID="&itDeconGel;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]decon gel"
 			level=				"3"
 			value=				"150"
@@ -774,18 +898,52 @@
 
 			description=		"Decon gel is used to decontaminate radioactive metals, ceramics and other materials. It is ideal for decontaminating a ship's armor and hull."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"decon"
 
 			sortName=			"decon gel, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<Events>
+			<OnUseOnItem>
+				(block (resultID)
+
+					(if (shpIsRadioactive gPlayerShip)
+						(block Nil
+							(shpDecontaminate gPlayerShip)
+							(setq resultID 'descResultDecontaminated)
+							)
+						(setq resultID 'descResultNotNeeded)
+						)
+
+					(objRemoveItem gPlayerShip gItem 1)
+					(itmSetKnown gItem)
+					{
+						nextScreen: 'exitScreen
+						desc: (itmTranslate gItem resultID)
+						}
+					)
+			</OnUseOnItem>
+		</Events>
+
+		<Language>
+			<Text id="descResultDecontaminated">
+				The barrel was filled with a decontamination gel.
+				Your ship has been decontaminated.
+			</Text>
+			<Text id="descResultNotNeeded">
+				The barrel was filled with a decontamination gel.
+				Since your ship is not radioactive, the gel has no effect.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Degenerating Nanos -->
 
 	<ItemType UNID="&itDegeneratingNanos;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]degenerating nanos"
 			level=				"4"
 			value=				"25"
@@ -797,18 +955,29 @@
 
 			description=		"These nanomachines are used to recycle old ships and armors into their basic components. Use with caution: Do not allow contact with a ship's armor or hull."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"degenerating"
 
 			sortName=			"degenerating nanos, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x8200</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The paste is a nanomachine matrix that dissolves metals and composites.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Organic Acid -->
 
 	<ItemType UNID="&itOrganicAcid;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]organic acid"
 			level=				"2"
 			value=				"15"
@@ -820,18 +989,53 @@
 
 			description=		"Powerful organic acids such as these are used in various industrial processes. Use with caution: Do not allow contact with a ship's armor or hull."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"acid"
 
 			sortName=			"organic acid, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<Events>
+			<OnUseOnItem>
+				(block (
+					(dstItem (@ gData 'itemToUseOn))
+					)
+					(switch
+						(not (itmMatches dstItem "aI"))
+							Nil
+
+						(block Nil
+							(shpDamageArmor gPlayerShip dstItem 2 (rollDice 3 6 0))
+
+							;	Remove the armor paste from the player's cargo
+							(objRemoveItem gPlayerShip gItem 1)
+
+							;	Identify the item
+							(itmSetKnown gItem)
+
+							{
+								desc: (itmTranslate gItem 'descResult)
+								}
+							)
+						)
+					)
+			</OnUseOnItem>
+		</Events>
+
+		<Language>
+			<Text id="descResult">
+				Unfortunately, the barrel contained an organic acid that eats
+				through most metals. Your armor has been damaged.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Radioactive Waste -->
 
 	<ItemType UNID="&itRadioactiveWaste;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]radioactive waste"
 			level=				"4"
 			value=				"0"
@@ -843,18 +1047,73 @@
 
 			description=		"This is a titanium barrel filled with low and medium-level radioactive waste."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"radioactive"
 
 			sortName=			"radioactive waste, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<Events>
+			<OnUseOnItem>
+				(block (
+					(dstItem (@ gData 'itemToUseOn))
+					resultID
+					)
+					(switch
+						;	Already contaminated
+						(shpIsRadioactive gPlayerShip)
+							(setq resultID 'descResultAlreadyContaminated)
+
+						;	Applied to an installed armor segment with radiation immunity
+						(and (itmMatches dstItem "aI") (shpIsRadiationImmune gPlayerShip dstItem))
+							(setq resultID 'descResultImmune)
+
+						(block Nil
+							(if (itmMatches dstItem "aI")
+								(setq resultID 'descResultContaminated)
+								(setq resultID 'descResultContaminatedCargo)
+								)
+							(shpMakeRadioactive gPlayerShip)
+							)
+						)
+
+						(objRemoveItem gPlayerShip gItem 1)
+						(itmSetKnown gItem)
+						{
+							nextScreen: 'forceUndock
+							desc: (typTranslate &itRadioactiveWaste; resultID)
+							}
+						)
+					)
+			</OnUseOnItem>
+		</Events>
+
+		<Language>
+			<Text id="descResultAlreadyContaminated">
+				The barrel contained radioactive waste. Your ship is already
+				radioactive; the waste has no further effect.
+			</Text>
+			<Text id="descResultContaminated">
+				The barrel contained radioactive waste. Your ship has been
+				contaminated.
+			</Text>
+			<Text id="descResultImmune">
+				The barrel contained radioactive waste. Fortunately, your armor
+				is immune to radiation. The waste has no effect.
+			</Text>
+			<Text id="descResultContaminatedCargo">
+				The barrel contained radioactive waste which just emptied
+				inside your cargo hold. Your ship has been contaminated.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Reactive Armor Coating -->
 
 	<ItemType UNID="&itReactiveArmorCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]reactive armor coating"
 			level=				"1"
 			value=				"60"
@@ -866,18 +1125,29 @@
 
 			description=		"This coating reacts when hit by kinetic or chemical explosives and produces an opposite reaction that protect the underlying armor and hull."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"reactive"
 
 			sortName=			"reactive armor coating, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x0a15</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The paste is a reactive coating that resists kinetic and chemical explosion damage.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Reflective Armor Coating -->
 
 	<ItemType UNID="&itReflectiveArmorCoating;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]reflective armor coating"
 			level=				"3"
 			value=				"160"
@@ -889,18 +1159,29 @@
 
 			description=		"This coating is nearly perfectly reflective at all laser weapon wavelengths. A ship's armor coated with this substance will be immune to laser weapons."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"reflective"
 
 			sortName=			"reflective armor coating, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancement">0x030a</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The paste is a mirrored coating that reflects laser beams.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Regenerating Nanos -->
 
 	<ItemType UNID="&itRegeneratingNanos;"
+			inherit=			"&baStdPasteBarrel;"
 			name=				"[barrel(s) of ]regenerating nanos"
 			level=				"4"
 			value=				"350"
@@ -912,13 +1193,28 @@
 
 			description=		"The nanomachines are able to automatically regenerate any armor. Once treated with this paste an armor segment will continue to regenerate even if damaged further."
 
-			useScreen=			"&dsUseArmorCoating;"
+			useScreen=			"&dsRPGUseItemOnArmor;"
 			data=				"regenerating"
 
 			sortName=			"regenerating nanos, barrel of"
 			>
 
 		<Image imageID="&rsItems1;" imageX="96" imageY="96" imageWidth="96" imageHeight="96"/>
+
+		<StaticData>
+			<Data id="enhancementTable">
+				(
+					{	criteria:"a &lt;=10"	enhancement:0x0200	}
+					{	criteria:"a &gt;10"	enhancement:Nil	descID:'TooAdvanced	}
+					)
+			</Data>
+		</StaticData>
+
+		<Language>
+			<Text id="descResultIntro">
+				The paste is a nanomachine matrix that regenerates the armor segment.
+			</Text>
+		</Language>
 	</ItemType>
 
 	<!-- Barrel of Repairing Nanos -->


### PR DESCRIPTION
This PR contains the start of a new item use framework / updated item dockscreens (see [ministry ticket](https://ministry.kronosaur.com/record.hexm?id=72328)). 

* So far all armor repair items and barrels are updated to use new system (so addresses part of [56054](https://ministry.kronosaur.com/record.hexm?id=56054))
* Using repair items / barrels though the normal way goes directly to `dsRPGUseItemOnArmor` - i.e. maintains old behavior but using an armorSelector screen
* Effects are now implemented as item events `CanUseOnItem` and `OnUseOnItem`, so it should be much easier to add new enhancement items without editing vanilla dockscreens.
* Using items via the cargo menu allows the player to apply the item to any armor / device / cargo item (though currently the only additional action supported is to empty radioactive waste inside the cargo hold)
* New dockscreens and base items (baStdArmorRepair / baStdPasteBarrel) added to RPGLibrary
* `dsUseArmorPatch`, `dsUseArmorCoating` and `useRepairArmor` are no longer used (could be made obsolete now?)