### PR TITLE
Include previous fates in game stats

### DIFF
--- a/Transcendence/CTranscendenceModel.cpp
+++ b/Transcendence/CTranscendenceModel.cpp
@@ -1050,6 +1050,16 @@ void CTranscendenceModel::GenerateGameStats (CGameStats *retStats, bool bGameOve
 
 			m_sEpitaph = NULL_STR;
 			}
+		//	Add previous fates below
+		for (int iIndex = 0; iIndex < m_GameRecord.GetPreviousEpitaphCount() - 1; iIndex++)
+			{
+			CString sPrevFate = m_GameRecord.GetPreviousEpitaph(iIndex);
+
+			if (strEquals(strWord(sPrevFate, 0), CONSTLIT("was")))
+				sPrevFate = strSubString(sPrevFate, 4, -1);
+
+			retStats->Insert(sPrevFate, NULL_STR, CONSTLIT("Previous Fates"));
+			}
 		}
 
 	//	Generate
@@ -1991,6 +2001,7 @@ void CTranscendenceModel::RecordFinalScore (const CString &sEpitaph, const CStri
 
 	m_GameRecord.SetEndGameReason(sEndGameReason);
 	m_GameRecord.SetEndGameEpitaph(sEpitaph);
+	m_GameRecord.AddEpitaph(sEpitaph);
 	m_GameRecord.SetPlayTime(m_Universe.StopGameTime());
 
 	m_GameRecord.SetRegistered(m_Universe.IsRegistered());


### PR DESCRIPTION
Please see the Mammoth pull request
`
Some Random Person

Adventure	Domina & Oracus I: The Stars of the Pilgrim
Domina relationship	Novice
Fate	Destroyed by the explosion of a Centurion-class heavy gunship in the Eridani System
Game	Unregistered
Genome	Human male
Money (credits)	1,965
Score	0
Ship class	Sapphire-class yacht
Time played	20.4 seconds
Version	1.8 Alpha 3

COMBAT

Friendly stations destroyed	1

CONDUCTS

Game resurrections	4
Never backtracked	
Never invoked powers of Domina	

DAMAGE SUSTAINED

reactive armor	37
class I deflector	35

EXPLORATION

Systems visited	1
Never reached Rigel Aurelius	
Never reached St. Katharine's Star	
Never reached Jiang's Star	
Never reached Point Juno	
Never reached Heretic	
Never reached the Galactic Core	

EXTENSIONS

Commonwealth Police 0.70	
The Stars of the Pilgrim HD	
The Stars of the Pilgrim Soundtrack	

FINAL EQUIPMENT

recoilless cannon	
class I deflector	
4 segments of reactive armor	
Nova-15 reactor	

FINAL ITEMS

12 helium³ fuel rods	

FRIENDLY STATIONS DESTROYED

Commonwealth dry dock	1

ITEMS INSTALLED

Nova-15 reactor	
reactive armor	
class I deflector	
recoilless cannon	

PREVIOUS FATES

destroyed by a Centurion-class heavy gunship in the Eridani System	
destroyed by a corporate cruiser in the Eridani System	
destroyed by an Officer Colin Freas in the Eridani System	
destroyed by an Officer Nimatek in the Eridani System	
`