### PR TITLE
rpgMissionAssignment changes

### DIFF
--- a/TransCore/RPGMissions.xml
+++ b/TransCore/RPGMissions.xml
@@ -871,7 +871,7 @@
 						;	Make a list of available missions. We filter out any missions
 						;	that are outside our system level. If we can't find anything, then we've got nothing.
 
-						(not (setq newMissions (typFind (@ options 'missionCriteria))))
+						(not (setq newMissions (typFind (cat (@ options 'missionCriteria) " -special;"))))
 							(scrShowScreen gScreen &dsRPGMessage; { desc:(scrTranslate gScreen noMissionTextID) })
 
 						;	Create a random mission from the list. If we succeed, then show the mission
@@ -946,7 +946,7 @@
 
 						;	Make a list of available missions. We filter out any missions
 						;	that are outside our system level. If we can't find anything, then we've got nothing.
-						(not (setq newMissions (typFind (@ options 'missionCriteria))))
+						(not (setq newMissions (typFind (cat (@ options 'missionCriteria) " -special;"))))
 							Nil
 
 						;	Create a random mission from the list. If we succeed, then return it

--- a/TransCore/RPGMissions.xml
+++ b/TransCore/RPGMissions.xml
@@ -820,6 +820,9 @@
 				;
 				;		intervalPerType: Time between missions given by same station type
 				;
+				;		maxActive: Maximum number of missions (meeting missionCriteria) which can
+				;				be active at the same time
+				;
 				;		maxPerStation: Maximum number of missions that we give out at
 				;				this station.
 				;
@@ -859,6 +862,9 @@
 				;
 				;		intervalPerType: Time between missions given by same station type
 				;
+				;		maxActive: Maximum number of missions (meeting missionCriteria) which can
+				;				be active at the same time
+				;
 				;		maxPerStation: Maximum number of missions that we give out at
 				;				this station.
 				;
@@ -883,6 +889,12 @@
 						;	If we have an open mission available then return it.
 						(setq theMission (msnFind gSource (cat "oSP " displayCriteria)))
 							theMission
+
+						;	If the player has too many active missions from other stations, then no new mission
+						(and (@ options 'maxActive)
+								(geq (count (msnFind Nil (cat "a" (@ options 'missionCriteria)))) (@ options 'maxActive))
+								)
+							Nil
 
 						;	Don't give out more than X mission per station
 						(and (@ options 'maxPerStation)

--- a/TransCore/RPGMissions.xml
+++ b/TransCore/RPGMissions.xml
@@ -877,11 +877,11 @@
 
 					(switch
 						;	If we have an active mission from this station then we return it.
-						(setq theMission (@ (msnFind gSource (cat "aS " displayCriteria)) 0))
+						(setq theMission (msnFind gSource (cat "aSP " displayCriteria)))
 							theMission
 
 						;	If we have an open mission available then return it.
-						(setq theMission (@ (msnFind gSource (cat "oS " displayCriteria)) 0))
+						(setq theMission (msnFind gSource (cat "oSP " displayCriteria)))
 							theMission
 
 						;	Don't give out more than X mission per station

--- a/TransCore/RPGMissions.xml
+++ b/TransCore/RPGMissions.xml
@@ -834,60 +834,15 @@
 				
 				(block (
 					(noMissionTextID (@ options 'noMissionTextID))
-					(displayCriteria (@ options 'displayCriteria))
-					theMission newMissions nextMissionTime
+					theMission
 					)
 
 					;	Show proper screen
 
 					(switch
-						;	If we have an active mission from this station then we show it.
-
-						(setq theMission (@ (msnFind gSource (cat "aS " displayCriteria)) 0))
+						;	Call rpgMissionGetAssignment to see if we have a mission.
+						(setq theMission (rpgMissionGetAssignment options))
 							(scrShowScreen gScreen &dsRPGMission; {	missionObj: theMission })
-
-						;	If we have an open mission available then display it.
-
-						(setq theMission (@ (msnFind gSource (cat "oS " displayCriteria)) 0))
-							(scrShowScreen gScreen &dsRPGMission; {	missionObj: theMission })
-
-						;	Don't give out more than X mission per station
-								
-						(and (@ options 'maxPerStation) 
-								(geq (count (msnFind gSource "*S")) (@ options 'maxPerStation))
-								)
-							(scrShowScreen gScreen &dsRPGMessage; { desc:(scrTranslate gScreen noMissionTextID) })
-
-						;	If it's not time for a new mission, then nothing
-
-						(and (setq nextMissionTime (objGetData gSource 'nextMissionTime))
-								(gr nextMissionTime (unvGetTick)))
-							(scrShowScreen gScreen &dsRPGMessage; { desc:(scrTranslate gScreen noMissionTextID) })
-
-						(and (setq nextMissionTime (objGetTypeData gSource 'nextMissionTime))
-								(gr nextMissionTime (unvGetTick)))
-							(scrShowScreen gScreen &dsRPGMessage; { desc:(scrTranslate gScreen noMissionTextID) })
-
-						;	Make a list of available missions. We filter out any missions
-						;	that are outside our system level. If we can't find anything, then we've got nothing.
-
-						(not (setq newMissions (typFind (cat (@ options 'missionCriteria) " -special;"))))
-							(scrShowScreen gScreen &dsRPGMessage; { desc:(scrTranslate gScreen noMissionTextID) })
-
-						;	Create a random mission from the list. If we succeed, then show the mission
-						;	screen.
-
-						(setq theMission (msnCreate newMissions gSource))
-							(block Nil
-								;	And set next mission times if required
-								(if (@ options 'intervalPerStation)
-									(objSetData gSource 'nextMissionTime (+ (unvGetTick) (@ options 'intervalPerStation)))
-									)
-								(if (@ options 'intervalPerType)
-									(objSetTypeData gSource 'nextMissionTime (+ (unvGetTick) (@ options 'intervalPerType)))
-									)
-								(scrShowScreen gScreen &dsRPGMission; { missionObj: theMission })
-								)
 
 						; Otherwise, nothing
 


### PR DESCRIPTION
1. rpgMissionAssignment will no longer create new missions with the `special` attribute
This is consistent with the use of the `special` attribute in corpPriv_showMissionScreen and is intended for special missions which should not be automatically created by stations (but if they are created and open/active then the station should display them)
There are several missions which expect this behavior (e.g. Kronosaurus mission and some which are created in OnGlobalSystemStarted events). Most of these work because displayCriteria is rarely set at the moment, but now that it is being used more some of the missions are starting to break (see also #69)
2. rpgMissionAssignment now calls rpgMissionGetAssignment rather than having two near-identical sets of code
3. Uses `P` priority criteria so the highest priority active/open mission will be shown if multiple are available.