### PR TITLE
Debug-only Save Menu options

### DIFF
--- a/Transcendence/CTranscendenceController.cpp
+++ b/Transcendence/CTranscendenceController.cpp
@@ -73,6 +73,7 @@
 
 #define CMD_GAME_ADVENTURE						CONSTLIT("gameAdventure")
 #define CMD_GAME_CREATE							CONSTLIT("gameCreate")
+#define CMD_GAME_END_DELETE						CONSTLIT("gameEndDelete")
 #define CMD_GAME_END_DESTROYED					CONSTLIT("gameEndDestroyed")
 #define CMD_GAME_END_GAME						CONSTLIT("gameEndGame")
 #define CMD_GAME_END_SAVE						CONSTLIT("gameEndSave")
@@ -1011,6 +1012,24 @@ ALERROR CTranscendenceController::OnCommand (const CString &sCmd, void *pData)
 		//	Epilogue
 
 		HICommand(CMD_UI_START_EPILOGUE);
+		}
+
+	//	Quit the game and delete the save file
+
+	else if (strEquals(sCmd, CMD_GAME_END_DELETE))
+		{
+		if (error = m_Model.EndGameDelete(&sError))
+			g_pTrans->DisplayMessage(sError);
+
+		//	Back to intro screen
+
+		m_pGameSession = NULL;
+		if (m_Model.GetPlayer())
+			m_Model.GetPlayer()->SetGameSession(NULL);
+		m_HI.ShowSession(new CIntroSession(m_HI, m_Model, m_Settings, CIntroSession::isShipStats));
+		m_iState = stateIntro;
+		DisplayMultiverseStatus(m_Multiverse.GetServiceStatus());
+		m_Soundtrack.SetGameState(CSoundtrackManager::stateProgramIntro);
 		}
 
 	//	End destroyed state. We either go to the epilog or we

--- a/Transcendence/CTranscendenceController.cpp
+++ b/Transcendence/CTranscendenceController.cpp
@@ -85,6 +85,7 @@
 #define CMD_GAME_LOAD_DONE						CONSTLIT("gameLoadDone")
 #define CMD_GAME_PAUSE							CONSTLIT("gamePause")
 #define CMD_GAME_READY							CONSTLIT("gameReady")
+#define CMD_GAME_REVERT							CONSTLIT("gameRevert")
 #define CMD_GAME_SELECT_ADVENTURE				CONSTLIT("gameSelectAdventure")
 #define CMD_GAME_SELECT_SAVE_FILE				CONSTLIT("gameSelectSaveFile")
 #define CMD_GAME_STARGATE_SYSTEM_READY			CONSTLIT("gameStargateSystemReady")
@@ -1083,6 +1084,27 @@ ALERROR CTranscendenceController::OnCommand (const CString &sCmd, void *pData)
 
 		m_Soundtrack.NotifyGameStart();
 		m_Soundtrack.NotifyEnterSystem();
+		}
+
+	else if (strEquals(sCmd, CMD_GAME_REVERT))
+		{
+		CString sFilename = m_Model.GetGameFile().GetFilespec();
+		if (error = m_Model.EndGameNoSave(&sError))
+			g_pTrans->DisplayMessage(sError);
+
+        //	Back to intro screen
+
+		m_pGameSession = NULL;
+		if (m_Model.GetPlayer())
+			m_Model.GetPlayer()->SetGameSession(NULL);
+		m_HI.ShowSession(new CIntroSession(m_HI, m_Model, m_Settings, CIntroSession::isShipStats));
+		m_iState = stateIntro;
+		DisplayMultiverseStatus(m_Multiverse.GetServiceStatus());
+		m_Soundtrack.SetGameState(CSoundtrackManager::stateProgramIntro);
+
+		//	Load
+
+		HICommand(CMD_GAME_LOAD, &sFilename);
 		}
 
 	//	Player notifications

--- a/Transcendence/CTranscendenceModel.cpp
+++ b/Transcendence/CTranscendenceModel.cpp
@@ -724,6 +724,35 @@ ALERROR CTranscendenceModel::EndGameDestroyed (bool *retbResurrected)
 	return NOERROR;
 	}
 
+ALERROR CTranscendenceModel::EndGameNoSave (CString *retsError)
+
+//	EndGameNoSave
+//
+//	Ends the current game without saving. Does not activate Resurrection.
+
+	{
+	ASSERT(m_iState == stateInGame);
+
+	//	Clear resurrection flag
+
+	m_GameFile.ClearGameResurrect();
+
+	//	Clean up
+
+	m_pPlayer = NULL;
+
+	//	Close the game file
+
+	m_GameFile.Close();
+	m_Universe.Reinit();
+
+	//	Done
+
+	m_iState = stateGameOver;
+
+	return NOERROR;
+	}
+
 ALERROR CTranscendenceModel::EndGameSave (CString *retsError)
 
 //	EndGameSave

--- a/Transcendence/CTranscendenceModel.cpp
+++ b/Transcendence/CTranscendenceModel.cpp
@@ -615,6 +615,34 @@ ALERROR CTranscendenceModel::EndGameClose (CString *retsError)
 	return NOERROR;
 	}
 
+ALERROR CTranscendenceModel::EndGameDelete (CString *retsError)
+
+//	EndGameDelete
+//
+//	End the game, save the file, and then delete it
+
+	{
+	ASSERT(m_iState == stateInGame);
+
+	//	Clean up
+
+	m_pPlayer = NULL;
+
+	//	Close the game file and delete it
+
+	CString sFileSpec = m_GameFile.GetFilespec();
+	m_GameFile.Close();
+	fileDelete(sFileSpec);
+
+	m_Universe.Reinit();
+
+	//	Done
+
+	m_iState = stateGameOver;
+
+	return NOERROR;
+	}
+
 ALERROR CTranscendenceModel::EndGameDestroyed (bool *retbResurrected)
 
 //	EndGameDestroyed

--- a/Transcendence/GameScreen.cpp
+++ b/Transcendence/GameScreen.cpp
@@ -38,6 +38,7 @@
 #define CMD_PAUSE							100
 #define CMD_SAVE							101
 #define CMD_SELF_DESTRUCT					103
+#define CMD_DELETE							104
 
 #define CMD_CONFIRM							110
 #define CMD_CANCEL							111
@@ -215,6 +216,14 @@ bool CTranscendenceWnd::DoGameMenuCommand (DWORD dwCmd)
 	{
 	switch (dwCmd)
 		{
+		case CMD_DELETE:
+			m_CurrentMenu = menuNone;
+			g_pHI->HICommand(CONSTLIT("gameEndDelete"));
+
+			//	Kill the session
+
+			return false;
+
 		case CMD_PAUSE:
 			m_CurrentMenu = menuNone;
 			g_pHI->HICommand(CONSTLIT("uiShowHelp"));
@@ -970,6 +979,13 @@ void CTranscendenceWnd::ShowGameMenu (void)
 	m_MenuData.AddMenuItem(CONSTLIT("1"), CONSTLIT("Help [F1]"), 0, CMD_PAUSE);
 	m_MenuData.AddMenuItem(CONSTLIT("2"), CONSTLIT("Save & Quit"), 0, CMD_SAVE);
 	m_MenuData.AddMenuItem(CONSTLIT("3"), CONSTLIT("Self-Destruct"), 0, CMD_SELF_DESTRUCT);
+
+	//	Debug mode includes more special functions
+
+	if (g_pUniverse->InDebugMode())
+		{
+		m_MenuData.AddMenuItem(CONSTLIT("0"), CONSTLIT("Delete & Quit"), 0, CMD_DELETE);
+		}
 	m_MenuDisplay.Invalidate();
 	m_CurrentMenu = menuGame;
 	}

--- a/Transcendence/GameScreen.cpp
+++ b/Transcendence/GameScreen.cpp
@@ -39,6 +39,7 @@
 #define CMD_SAVE							101
 #define CMD_SELF_DESTRUCT					103
 #define CMD_DELETE							104
+#define CMD_REVERT							105
 
 #define CMD_CONFIRM							110
 #define CMD_CANCEL							111
@@ -229,6 +230,11 @@ bool CTranscendenceWnd::DoGameMenuCommand (DWORD dwCmd)
 			g_pHI->HICommand(CONSTLIT("uiShowHelp"));
 			return true;
 
+		case CMD_REVERT:
+			m_CurrentMenu = menuNone;
+			g_pHI->HICommand(CONSTLIT("gameRevert"));
+			return false;
+
 		case CMD_SAVE:
 			m_CurrentMenu = menuNone;
 			g_pHI->HICommand(CONSTLIT("gameEndSave"));
@@ -251,7 +257,6 @@ bool CTranscendenceWnd::DoGameMenuCommand (DWORD dwCmd)
 			//	We return FALSE because we're putting up a new menu.
 
 			return false;
-
 		default:
 			m_CurrentMenu = menuNone;
 			return true;
@@ -984,6 +989,7 @@ void CTranscendenceWnd::ShowGameMenu (void)
 
 	if (g_pUniverse->InDebugMode())
 		{
+		m_MenuData.AddMenuItem(CONSTLIT("9"), CONSTLIT("Revert"), 0, CMD_REVERT);
 		m_MenuData.AddMenuItem(CONSTLIT("0"), CONSTLIT("Delete & Quit"), 0, CMD_DELETE);
 		}
 	m_MenuDisplay.Invalidate();

--- a/Transcendence/Transcendence.h
+++ b/Transcendence/Transcendence.h
@@ -984,6 +984,7 @@ class CTranscendenceModel
 		ALERROR EndGame (void);
 		ALERROR EndGame (const CString &sReason, const CString &sEpitaph, int iScoreChange = 0);
 		ALERROR EndGameClose (CString *retsError = NULL);
+		ALERROR EndGameDelete (CString *retsError = NULL);
 		ALERROR EndGameDestroyed (bool *retbResurrected = NULL);
 		ALERROR EndGameSave (CString *retsError = NULL);
 		ALERROR EndGameStargate (void);

--- a/Transcendence/Transcendence.h
+++ b/Transcendence/Transcendence.h
@@ -986,6 +986,7 @@ class CTranscendenceModel
 		ALERROR EndGameClose (CString *retsError = NULL);
 		ALERROR EndGameDelete (CString *retsError = NULL);
 		ALERROR EndGameDestroyed (bool *retbResurrected = NULL);
+		ALERROR EndGameNoSave (CString * retsError = NULL);
 		ALERROR EndGameSave (CString *retsError = NULL);
 		ALERROR EndGameStargate (void);
 		ALERROR EnterScreenSession (CSpaceObject *pLocation, CDesignType *pRoot, const CString &sScreen, const CString &sPane, ICCItem *pData, CString *retsError = NULL);


### PR DESCRIPTION
Adds two new Save Menu options
1. Delete & Quit: Quits the game and deletes the save file. Useful for when you need to test a mod that only takes effect after creating a new game.
2. Revert: Quits the game without saving and then immediately reloads it. Does not count as a resurrect. Useful for when you want to make a checkpoint for testing and reload to it after every test.

Requires: https://github.com/kronosaur/Mammoth/pull/37