### PR TITLE
Debug console scrolling

### DIFF
--- a/Transcendence/CTranscendenceWnd.cpp
+++ b/Transcendence/CTranscendenceWnd.cpp
@@ -13,8 +13,8 @@
 #define TEXT_CRAWL_HEIGHT					320
 #define TEXT_CRAWL_WIDTH					384
 
-#define DEBUG_CONSOLE_WIDTH					512
-#define DEBUG_CONSOLE_HEIGHT				600
+#define DEBUG_CONSOLE_WIDTH					0.5
+#define DEBUG_CONSOLE_HEIGHT				0.8
 
 int g_cxScreen = 0;
 int g_cyScreen = 0;
@@ -729,12 +729,13 @@ LONG CTranscendenceWnd::WMCreate (CString *retsError)
 		}
 
 	//	Initialize debug console
-
 	RECT rcRect;
-	rcRect.left = m_rcScreen.right - (DEBUG_CONSOLE_WIDTH + 4);
-	rcRect.top = (RectHeight(m_rcScreen) - DEBUG_CONSOLE_HEIGHT) / 2;
-	rcRect.right = rcRect.left + DEBUG_CONSOLE_WIDTH;
-	rcRect.bottom = rcRect.top + DEBUG_CONSOLE_HEIGHT;
+	int cxDebugWin = int(RectWidth(m_rcScreen) * DEBUG_CONSOLE_WIDTH);
+	int cyDebugWin = int(RectHeight(m_rcScreen) * DEBUG_CONSOLE_HEIGHT);
+	rcRect.left = m_rcScreen.right - (cxDebugWin + 4);
+	rcRect.top = (RectHeight(m_rcScreen) - cyDebugWin) / 2;
+	rcRect.right = rcRect.left + cxDebugWin;
+	rcRect.bottom = rcRect.top + cyDebugWin;
 	m_DebugConsole.SetFontTable(&m_Fonts);
 	m_DebugConsole.Init(this, rcRect);
 

--- a/Transcendence/Transcendence.h
+++ b/Transcendence/Transcendence.h
@@ -592,7 +592,7 @@ class CCommandLineDisplay
 	private:
 		enum Constants
 			{
-			MAX_LINES = 80,
+			MAX_LINES = 200,
 			};
 
 		void AppendOutput (const CString &sLine, CG32bitPixel rgbColor);

--- a/Transcendence/Transcendence.h
+++ b/Transcendence/Transcendence.h
@@ -573,7 +573,7 @@ class CCommandLineDisplay
 
 		void CleanUp (void);
 		inline void ClearInput (void) { m_sInput = NULL_STR; m_iCursorPos = 0; m_bInvalid = true; }
-		inline void ClearHint (void) { m_sHint = NULL_STR; m_bInvalid = true; }
+		inline void ClearHint (void) { m_sHint = NULL_STR; m_iScrollPos = 0; m_bInvalid = true; }
 		inline const CString &GetInput (void) { return m_sInput; }
 		inline int GetOutputLineCount (void) { return GetOutputCount(); }
 		inline const RECT &GetRect (void) { return m_rcRect; }
@@ -621,7 +621,7 @@ class CCommandLineDisplay
 		int m_iHistoryEnd;
 		int m_iHistoryIndex;
 		int m_iCursorPos;
-
+		int m_iScrollPos;
 
 		CG32bitImage m_Buffer;
 		bool m_bInvalid;


### PR DESCRIPTION
This adds simple scrolling to the debug console with PgUp/PgDn
* The current input line is always displayed. Scrolling affects output and autohint lines
* Scrolling resets when output/hintline is updated. Editing input line does not affect scroll

Also scales console to occupy 50% width and 80% height of screen

Fixes: [72526](https://ministry.kronosaur.com/record.hexm?id=72526)