### PR TITLE
Rumors and Raisu Station

### DIFF
--- a/TransCore/Abbasid.xml
+++ b/TransCore/Abbasid.xml
@@ -85,7 +85,6 @@
 				{
 					attributes: "commonwealthPub"
 					priority: 22
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}

--- a/TransCore/Abbasid.xml
+++ b/TransCore/Abbasid.xml
@@ -86,14 +86,14 @@
 					attributes: "commonwealthPub"
 					priority: 22
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}
 			</GetRumors>
 		</Events>
 
 		<Language>
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				A woman weeps softly as she tells her story:
 
 				"Our freighter strayed near an Abbasid outpost by mistake.

--- a/TransCore/BattleArena.xml
+++ b/TransCore/BattleArena.xml
@@ -248,6 +248,7 @@
 							(seededRandom (objGetDestiny (@ gData 'stationObj)) 1 3)
 							)
 						}
+					(rpgRumorAdd 'commonwealthContainer (make 'sequence 1 4) 100)
 					)
 			</GetRumors>
 
@@ -1765,6 +1766,22 @@
 				how important shields are. If you can afford the Ceratops series then go for
 				it. They're the best against missiles anyway, which is what you're gonna get
 				hit with in the Arena."
+			</Text>
+			<String id="rumor.commonwealthContainer.1">
+				"The Slicer is the champion of the Arena! No one has been able to defeat him."
+			</String>
+			<Text id="rumor.commonwealthContainer.2">
+				"I don't watch the Arena games anymore; the Black Market has totally
+				infiltrated the show and all the fights are rigged now."
+			</Text>
+			<Text id="rumor.commonwealthContainer.3">
+				"I remember watching Kate Morgental fight in the Arena. She put on a great
+				show! I don't know what happened to her; probably working for her father now."
+			</Text>
+			<Text id="rumor.commonwealthContainer.4">
+				"Let me tell you a secret about fighting in the Arena: load up with missiles.
+				Who cares about beams and whatnot; a good missile will cut through armor like
+				a knife through Salmonite!"
 			</Text>
 
             <Text id="core.mapDescMain">

--- a/TransCore/BattleArena.xml
+++ b/TransCore/BattleArena.xml
@@ -232,6 +232,27 @@
 					)
 			</GetGlobalAchievements>
 
+			<GetRumors>
+				(append
+					{
+						attributes: 'commonwealthHabitat
+						priority: 100
+						sourceObj: gSource
+						textID: (cat "rumor.commonwealthHabitat.weapon"
+							(seededRandom (objGetDestiny (@ gData 'stationObj)) 1 5)
+							)
+						}
+					{
+						attributes: 'commonwealthHabitat
+						priority: 100
+						sourceObj: gSource
+						textID: (cat "rumor.commonwealthHabitat.shield"
+							(seededRandom (objGetDestiny (@ gData 'stationObj)) 1 3)
+							)
+						}
+					)
+			</GetRumors>
+
 			<OnCreate>
 				(block (classList gladiatorList)
 					; Load the list of standard gladiator classes
@@ -1705,6 +1726,49 @@
 			
 			</String>
             
+			<Text id="rumor.commonwealthHabitat.weapon1">
+				"What's your favorite weapon? Personally I favor the AK505 Ballista. It's
+				a monster and it will kill a lot of ships with a single punch. When I hit
+				something, I want it to go down, you know what I mean?"
+			</Text>
+			<Text id="rumor.commonwealthHabitat.weapon2">
+				"What's your favorite weapon? Personally I favor a particle beam weapon.
+				The latest tech is always going to win in the end. You have to keep up
+				with technology or you're just another wreck in the Arena."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.weapon3">
+				"What's your favorite weapon? Personally I favor an omni turbolaser. I say
+				a computer can hit a target way better than I can, so why not take
+				advantage of that? By the time your opponent has lined up his BFG, you've
+				already hit him five times!"
+			</Text>
+			<Text id="rumor.commonwealthHabitat.weapon4">
+				"What's your favorite weapon? Personally I favor a slam cannon, enhanced
+				if possible. There's nothing better than the thump-thump sounds of a slam
+				cannon hitting your enemy's plasteel!"
+			</Text>
+			<Text id="rumor.commonwealthHabitat.weapon5">
+				"What's your favorite weapon? Personally I favor the RK15 Partisan turret.
+				Sure, the wimpy omniturbo is a little faster, but I wanna hit my targets
+				with a punch, not shine a damn light in their eyes."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.shield1">
+				"So what kind of shields you got? I think a lot of gladiators underestimate
+				how important shields are. Even a good monopole deflector is better than
+				nothing. I'd enhance the crap out of it, though."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.shield2">
+				"So what kind of shields you got? I think a lot of gladiators underestimate
+				how important shields are. The Cyclotron series are my choice at the moment.
+				The S55 has more protection than a class III; better yet, get the S1200."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.shield3">
+				"So what kind of shields you got? I think a lot of gladiators underestimate
+				how important shields are. If you can afford the Ceratops series then go for
+				it. They're the best against missiles anyway, which is what you're gonna get
+				hit with in the Arena."
+			</Text>
+
             <Text id="core.mapDescMain">
                 Gladiatorial combat
             </Text>

--- a/TransCore/BattleArena.xml
+++ b/TransCore/BattleArena.xml
@@ -237,7 +237,6 @@
 					{
 						attributes: 'commonwealthHabitat
 						priority: 100
-						sourceObj: gSource
 						textID: (cat "rumor.commonwealthHabitat.weapon"
 							(seededRandom (objGetDestiny (@ gData 'stationObj)) 1 5)
 							)
@@ -245,7 +244,6 @@
 					{
 						attributes: 'commonwealthHabitat
 						priority: 100
-						sourceObj: gSource
 						textID: (cat "rumor.commonwealthHabitat.shield"
 							(seededRandom (objGetDestiny (@ gData 'stationObj)) 1 3)
 							)

--- a/TransCore/BlackMarket.xml
+++ b/TransCore/BlackMarket.xml
@@ -438,7 +438,7 @@ PLAYER DATA
 					attributes: "commonwealthPub"
 					priority: 31
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}
 			</GetRumors>
@@ -465,7 +465,7 @@ PLAYER DATA
 				(cat "We install smuggler's equipment up to tech level " (objGetProperty gSource 'installDeviceMaxLevel) ".")
 			</Text>
 
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				A woman dressed in a fancy neolinen suit talks to you:
 
 				"Do you know how to get a contact at the black market station?
@@ -775,7 +775,7 @@ PLAYER DATA
 					attributes: "commonwealthPub"
 					priority: 23
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}
 			</GetRumors>
@@ -794,7 +794,7 @@ PLAYER DATA
 				They check you out and then step aside to let you in.
 
 			</Text>
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				A man dressed in an expensive suit talks to you:
 
 				"You look like you need some Tempus."

--- a/TransCore/BlackMarket.xml
+++ b/TransCore/BlackMarket.xml
@@ -437,7 +437,6 @@ PLAYER DATA
 				{
 					attributes: "commonwealthPub"
 					priority: 31
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}
@@ -774,7 +773,6 @@ PLAYER DATA
 				{
 					attributes: "commonwealthPub"
 					priority: 23
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}

--- a/TransCore/CentauriWarlords.xml
+++ b/TransCore/CentauriWarlords.xml
@@ -748,15 +748,7 @@
 
 						;	Arco attacks the player
 						
-						(block Nil
-							(shpCancelOrders arcoVaughnObj)
-							(shpOrder arcoVaughnObj 'attack gPlayerShip)
-							(objSetData arcoVaughnObj "behavior" 'killPlayer)
-
-							(objSendMessage gPlayerShip arcoVaughnObj
-								(random (objGetStaticData arcoVaughnObj "msgTableWTF"))
-								)
-							)
+						(objFireEvent arcoVaughnObj 'OrderKillPlayer)
 						)
 					)
 			</OnAttacked>

--- a/TransCore/CentauriWarlords.xml
+++ b/TransCore/CentauriWarlords.xml
@@ -668,7 +668,7 @@
 					attributes: "commonwealthPub"
 					priority: 10
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					data: {station: (objGetName gSource)}
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}
@@ -800,7 +800,7 @@
 
 			</Text>
 
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				You listen to a refugee from %station%:
 
 				"Centauri warlords took over our station last month.

--- a/TransCore/CentauriWarlords.xml
+++ b/TransCore/CentauriWarlords.xml
@@ -175,29 +175,7 @@
 	
 <!-- SHIP CLASSES -->
 
-	<!-- Arco Vaughn's Heavy Raider
-
-	GLOBAL DATA
-
-	destroyedByPlayer:	True if destroyed by player
-
-	status:				Status of Arco Vaughn
-							Nil						= never encountered
-							"destroyed"				= destroyed
-
-	EXTRA DATA
-
-	home:				Our container
-
-	behavior:			Current behavior
-							Nil						= waiting for player
-							'scarePlayer			= scare the player, shoot if shields are full
-							'scarePlayerWithForce	= shoot at player but stop when shields drop
-							'killPlayer				= kill the player
-
-	warning:			True if we warned the player
-
-	-->
+	<!-- Arco Vaughn's Heavy Raider -->
 
 	<ShipClass UNID="&scArcoVaughnHeavyRaider;"
 			manufacturer=		"Centauri"
@@ -281,217 +259,16 @@
 			perception=			"4"
 			/>
 
-		<StaticData>
-			<msgTableGoHome>
-				(
-					"Go home before you hurt yourself, kid"
-					"This isn't your fight; get out while you can"
-					"That was a warning"
-					"This is a restricted area; I will shoot"
-					"Go home; this system is mine!"
-					"Don't make me destroy you"
-					)
-			</msgTableGoHome>
-
-			<msgTableTickled>
-				(
-					"Quit it!"
-					"Go home kid, or I'm really going to get mad"
-					"What, did I kill your microsaur or something?"
-					"Forget it, you don't have a chance!"
-					"Clear out or I will blast you!"
-					"Don't make me bust you up"
-					)
-			</msgTableTickled>
-
-			<msgTableWTF>
-				(
-					"What the...!?"
-					"You are going to die!"
-					"You are dead!"
-					"Enough!"
-					"Kack!"
-					"Huh!?"
-					)
-			</msgTableWTF>
-		</StaticData>
-
 		<Events>
-			<OnAttacked>
-				(if (and (eq aOrderGiver gPlayerShip) 
-						(not (eq (objGetData gSource "behavior") 'killPlayer)))
-					(if (and (or (eq aDamageType 'kinetic) (eq aDamageType 'laser))
-							(leq aDamageHP 6)
-							)
-
-						; If we're attacked with laser or kinetic, laugh it off
-
-						(if (and (eq (random 1 3) 1)
-								(eq (objGetData gSource "behavior") 'scarePlayer))
-							(objSendMessage gPlayerShip gSource
-								(random (objGetStaticData gSource "msgTableTickled"))
-								)
-							)
-
-						; If we're attacked with something more powerful, then we
-						; attack in force.
-
-						(block Nil
-							(shpCancelOrders gSource)
-							(shpOrder gSource 'attack gPlayerShip)
-							(objSetData gSource "behavior" 'killPlayer)
-
-							(objSendMessage gPlayerShip gSource
-								(random (objGetStaticData gSource "msgTableWTF"))
-								)
-							)
-						)
-					)
-			</OnAttacked>
-
-			<OnBehavior>
-				(block (behavior playerDist)
-					(setq behavior (objGetData gSource "behavior"))
-
-					(switch
-						; Wait for player to show up
-						(not behavior)
-							(if (and gPlayerShip 
-									(ls (objGetDistance gPlayerShip gSource) 60)
-									(ls (objGetDistance gPlayerShip (objGetObjRefData gSource "home")) 200))
-								(block Nil
-
-									; Once the player shows up, aim for the player, but don't attack yet
-									(shpCancelOrders gSource)
-									(shpOrder gSource 'aim gPlayerShip)
-
-									(objRegisterForEvents gSource gPlayerShip)
-									(objSetData gSource "behavior" 'scarePlayer)
-									)
-								)
-
-						; Scare the player away
-						(eq behavior 'scarePlayer)
-							(block Nil
-								(if (eq (objGetShieldLevel gPlayerShip) 100)
-									(block Nil
-										(shpCancelOrders gSource)
-										(shpOrder gSource 'attack gPlayerShip)
-										(objSetData gSource "behavior" 'scarePlayerWithForce)
-										)
-									)
-
-								(if (gr (objGetDistance gPlayerShip (objGetObjRefData gSource "home")) 300)
-									(block Nil
-										(shpCancelOrders gSource)
-										(shpOrder gSource 'patrol (objGetObjRefData gSource "home") 5)
-										(objSetData gSource "behavior" Nil)
-										(objSetData gSource "warning" Nil)
-										)
-									)
-								)
-
-						(eq behavior 'scarePlayerWithForce)
-							(block Nil
-								(if (ls (objGetShieldLevel gPlayerShip) 100)
-									(block Nil
-										(shpCancelOrders gSource)
-										(shpOrder gSource 'aim gPlayerShip)
-										(objSetData gSource "behavior" 'scarePlayer)
-										)
-									)
-
-								(if (and 
-										(not (objGetData gSource "warning"))
-										(ls (objGetDistance gSource gPlayerShip) 25)
-										)
-									(block Nil
-										(objSendMessage gPlayerShip gSource
-											(random (objGetStaticData gSource "msgTableGoHome"))
-											)
-										(objSetData gSource "warning" True)
-										)
-									)
-
-								(if (gr (objGetDistance gPlayerShip (objGetObjRefData gSource "home")) 300)
-									(block Nil
-										(shpCancelOrders gSource)
-										(shpOrder gSource 'patrol (objGetObjRefData gSource "home") 5)
-										(objSetData gSource "behavior" Nil)
-										(objSetData gSource "warning" Nil)
-										)
-									)
-								)
-						)
-					)
-			</OnBehavior>
-
 			<OnCreate>
 				(block Nil
 					; Vaughn's armor is resistant to laser and kinetic (only 20% damage gets through)
 					(objEnumItems gSource "aI" theItem
 						(shpEnhanceItem gSource theItem 0x0808)
 						)
-
-					; Set a timer so that we can do some custom behavior
-					(sysAddObjRecurringTimerEvent 10 gSource "OnBehavior")
-
-					; Remember our home
-					(objSetObjRefData gSource "home" (sysFindObject gSource "TN +arcoVaughn;"))
 					)
 			</OnCreate>
-
-			<OnDamage>
-				(block Nil
-
-					; If the player damaged us, then attack
-					(if (and (eq aAttacker gPlayerShip) 
-							(not (eq (objGetData gSource "behavior") 'killPlayer)))
-						(block Nil
-							(shpCancelOrders gSource)
-							(shpOrder gSource 'attack gPlayerShip)
-							(objSetData gSource "behavior" 'killPlayer)
-
-							(objSendMessage gPlayerShip gSource
-								(random (objGetStaticData gSource "msgTableWTF"))
-								)
-							)
-						)
-
-					; We always return full hit points
-					aDamageHP
-					)
-			</OnDamage>
-
-			<OnDestroy>
-				(block Nil
-					(objSetGlobalData gSource "status" 'destroyed)
-
-					(if (and gPlayerShip (eq aOrderGiver gPlayerShip))
-						(objSetGlobalData gSource "destroyedByPlayer" True)
-						)
-					)
-			</OnDestroy>
-
-			<OnObjDestroyed>
-				(if (eq aObjDestroyed gPlayerShip)
-					(block Nil
-						(shpCancelOrders gSource)
-						(shpOrder gSource 'patrol (objGetObjRefData gSource "home") 5)
-						(objSetData gSource "behavior" Nil)
-						)
-					)
-			</OnObjDestroyed>
-
-			<OrderKillPlayer>
-				(block Nil
-					(shpCancelOrders gSource)
-					(shpOrder gSource 'attack gPlayerShip)
-					(objSetData gSource "behavior" 'killPlayer)
-					)
-			</OrderKillPlayer>
 		</Events>
-
 	</ShipClass>
 
 	<!-- Centauri Heavy Raider -->
@@ -946,30 +723,6 @@
 		</Items>
 
 		<Events>
-			<OnCreate>
-				(block (email)
-					(setq email (itmCreate &itDataROM; 1))
-					(setq email (itmSetData email "Text"
-						(cat
-							"RECEIVED from relay07.cynus.anderson.187janus_station.comm\n"
-							"by helios_receiver.f5astarton_eridani.comm (EID 089830_7188919)\n"
-							"for &lt;arcovaughn.17591&gt; (EID 089830_8179210) 2403-11-25 17:34:11\n\n"
-							"MESSAGE BEGINS\n"
-							"I know that you must hate me right now; truth is I don't like myself very much either. "
-							"But I promise you that everything happens for a reason and that one day you and I will both understand. "
-							"I can't explain to you or anyone why I'm going. No one can understand. "
-							"But I know that I am doing the right thing and I know that I am doing what I must. "
-							"I can't do anything else. Something is about to happen. Something feels wrong. "
-							"Whatever fate awaits me at the Core, I know that it is entwined with the fate of all Humanity. "
-							"When I get there, I will understand. When I get there, we will all understand. "
-							"I must get there before it is too late. Take care of your mother.\n\n"
-							"MESSAGE ENDS"
-							)
-						))
-					(objAddItem gSource email)
-					)
-			</OnCreate>
-			
 			<OnAttacked>
 				(block (
 					(arcoVaughnObj (sysFindObject Nil "sAN +arcoVaughn"))

--- a/TransCore/CentauriWarlords.xml
+++ b/TransCore/CentauriWarlords.xml
@@ -444,7 +444,6 @@
 				{
 					attributes: "commonwealthPub"
 					priority: 10
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					data: {station: (objGetName gSource)}
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))

--- a/TransCore/Commonwealth.xml
+++ b/TransCore/Commonwealth.xml
@@ -879,33 +879,6 @@
 			<Lookup count="1d4" table="&tbCommPrivateCrafts;"/>
 		</Ships>
 
-		<StaticData>
-			<RumorsBA>
-				(
-					(cat "\"What's your favorite weapon? Personally I favor "
-						(seededRandom (objGetDestiny gSource)
-							'(
-								"the AK505 Ballista. It's a monster and it will kill a lot of ships with a single punch. When I hit something, I want it to go down, you know what I mean?\""
-								"a particle beam weapon. The latest tech is always going to win in the end. You have to keep up with technology or you're just another wreck in the Arena.\""
-								"an omni turbolaser. I say a computer can hit a target way better than I can, so why not take advantage of that? By the time your opponent has lined up his BFG, you've already hit him five times!\""
-								"a slam cannon, enhanced if possible. There's nothing better than the thump-thump sounds of a slam cannon hitting your enemy's plasteel!\""
-								"the RK15 Partisan turret. Sure, the wimpy omniturbo is a little faster, but I wanna hit my targets with a punch, not shine a damn light in their eyes.\""
-								)
-							)
-						)
-					(cat "\"So what kind of shields you got? I think a lot of gladiators underestimate how important shields are. "
-						(seededRandom (objGetDestiny gSource)
-							'(
-								"Even a good monopole deflector is better than nothing. I'd enhance the crap out of it, though.\""
-								"The Cyclotron series are my choice at the moment. The S55 has more protection than a class III; better yet, get the S1200.\""
-								"If you can afford the Ceratops series then go for it. They're the best against missiles anyway, which is what you're gonna get hit with in the Arena.\""
-								)
-							)
-						)
-					)
-			</RumorsBA>
-		</StaticData>
-
 		<Events>
 			<GetGlobalAchievements>
 				(block (

--- a/TransCore/Commonwealth.xml
+++ b/TransCore/Commonwealth.xml
@@ -1101,36 +1101,6 @@
 					(Nil					0		'thanksForNothing)
 					)
 			</DonationTable>
-
-			<Rumors>
-				(
-					"\"The Charon pirates are a menace. They have bases in almost every system and they prey on defenseless freighters.\""
-					"\"If you need a contact in the Black Market find the Aleksany brothers; they're always doing business in some fancy hotel.\""
-					"\"The anarchists don't bother us, but they really annoy the Corporations: they're always stealing their fancy ROMs.\""
-					"\"Stay away from the Abbasid fortresses. Those fanatics will shoot you rather than let you get close.\""
-					"\"The Urak warlords are another nutty group, but their armor and weapons are pretty good.\""
-					"\"Hiro is the best hacker in the 'verse. He's created some fancy ROMs that even the cyber corporations can't figure out.\""
-					)
-			</Rumors>
-
-			<RumorsSE>
-				(
-					"\"Watch out for Arco Vaughn. He is the most dangerous Centauri warlord; his heavy raider is protected against lasers and recoilless cannons. Avoid him if you want to live.\""
-					"\"Arco Vaughn flies an enhanced heavy raider. His armor is protected against normal weapons; you'll need missiles to kill him.\""
-					"\"Raisu Station is in trouble. The Centauri warlords have taken it over; don't go there unless you are armed and ready.\""
-					"\"If you want to find Arco Vaughn, go to Raisu Station. Talk to the station master there. She will help you.\""
-					"\"The Centauri warlords have many bases among the outer asteroids of Eridani; but if you go there, watch out: Arco Vaughn is there too.\""
-					)
-			</RumorsSE>
-
-			<RumorsBA>
-				(
-					"\"The Slicer is the champion of the Arena! No one has been able to defeat him.\""
-					"\"I don't watch the Arena games anymore; the Black Market has totally infiltrated the show and all the fights are rigged now.\""
-					"\"I remember watching Kate Morgental fight in the Arena. She put on a great show! I don't know what happened to her; probably working for her father now.\""
-					"\"Let me tell you a secret about fighting in the Arena: load up with missiles. Who cares about beams and whatnot; a good missile will cut through armor like a knife through Salmonite!\""
-					)
-			</RumorsBA>
 		</StaticData>
 
 		<Events>
@@ -1193,6 +1163,10 @@
 					(shpOrder gPlayerShip 'dock aTargetObj)
 					)
 			</OrderDockWithTarget>
+
+			<GetGlobalRumors>
+				(rpgRumorAdd 'commonwealthContainer (make 'sequence 6))
+			</GetGlobalRumors>
 		</Events>
 
 		<DockScreens>
@@ -1220,7 +1194,6 @@
 					</Default>
 				</Panes>
 			</Main>
-
 		</DockScreens>
 
 		<DockingPorts>
@@ -1252,9 +1225,36 @@
 				us some of your worldly possessions; they won't do you much good at
 				the Core, or wherever you're trying to get."
 			</Text>
+			<String id="descNoRumors">
+				"Everything's quiet around here at the moment."
+			</String>
 
 			<Text id="rumor.intro">
 				The station master grabs you and speaks softly in your ear:\n\n
+			</Text>
+			<Text id="rumor.commonwealthContainer.1">
+				"The Charon pirates are a menace. They have bases in almost every
+				system and they prey on defenseless freighters."
+			</Text>
+			<Text id="rumor.commonwealthContainer.2">
+				"If you need a contact in the Black Market find the Aleksany
+				brothers; they're always doing business in some fancy hotel."
+			</Text>
+			<Text id="rumor.commonwealthContainer.3">
+				"The anarchists don't bother us, but they really annoy the
+				Corporations: they're always stealing their fancy ROMs."
+			</Text>
+			<Text id="rumor.commonwealthContainer.4">
+				"Stay away from the Abbasid fortresses. Those fanatics will
+				shoot you rather than let you get close."
+			</Text>
+			<Text id="rumor.commonwealthContainer.5">
+				"The Urak warlords are another nutty group, but their armor
+				and weapons are pretty good."
+			</Text>
+			<Text id="rumor.commonwealthContainer.6">
+				"Hiro is the best hacker in the 'verse. He's created some
+				fancy ROMs that even the cyber corporations can't figure out."
 			</Text>
 		</Language>
 	</StationType>
@@ -2180,7 +2180,13 @@
 							(= (scrGetData gScreen 'result) 'info)
 								(if (geq (objGetTypeData gSource 'donationPoints) 5)
 									(scrShowPane gScreen "RewardInfo")
-									(scrShowPane gScreen "RewardInfoRumors")
+									(block Nil
+										(scrExitScreen gScreen)
+										(rpgRumorShow {
+											rumorCriteria: "+commonwealthContainer"
+											noRumorTextID: 'descNoRumors
+											})
+										)
 									)
 
 							(scrExitScreen gScreen)
@@ -2244,30 +2250,6 @@
 					</Action>
 				</Actions>
 			</RewardInfo>
-
-			<RewardInfoRumors>
-				<OnPaneInit>
-					(scrSetDesc gScreen (cat
-						"The station master grabs you and speaks softly in your ear:\n\n"
-						(switch
-							(and (eq (sysGetNode) 'SE)
-									(not (eq (typGetGlobalData &scArcoVaughnHeavyRaider; "status") 'destroyed)))
-								(random (objGetStaticData gSource "RumorsSE"))
-
-							(eq (sysGetNode) 'BA)
-								(random (objGetStaticData gSource "RumorsBA"))
-
-							(random (objGetStaticData gSource "Rumors"))
-							)
-						))
-				</OnPaneInit>
-
-				<Actions>
-					<Action id="actionContinue" default="1" cancel="1">
-						(scrExitScreen gScreen)
-					</Action>
-				</Actions>
-			</RewardInfoRumors>
 
 			<RewardInfoEquipment>
 				<OnPaneInit>

--- a/TransCore/Commonwealth.xml
+++ b/TransCore/Commonwealth.xml
@@ -2797,6 +2797,7 @@
 									(setq allDests (filter (sysFindObject gSource "TAF +populated; -korolovShipping; -occupation;") theObj 
 										(and (gr (objGetOpenDockingPortCount theObj) 1)
 											(or (not dockedAt) (not (eq dockedAt theObj)))
+											(not (objFireEvent theObj 'GetTrafficStatus { aObj:gSource }))
 											)
 										))
 									)

--- a/TransCore/Commonwealth.xml
+++ b/TransCore/Commonwealth.xml
@@ -1209,12 +1209,8 @@
 						</OnPaneInit>
 
 						<Actions>
-							<Action name="Donate Item" key="D" default="1">
-								(block Nil
-									(setq gPrevScreen "Main")
-									(setq gPrevPane "Default")
-									(scrShowScreen gScreen "&dsContainerHabitatDonateItem;")
-									)
+							<Action id="actionDonate" default="1">
+								(scrShowScreen gScreen "&dsContainerHabitatDonateItem;")
 							</Action>
 
 							<Action id="actionUndock" cancel="1">
@@ -1238,6 +1234,8 @@
 		</DockingPorts>
 		
 		<Language>
+			<Text id="actionDonate">[D]onate Item</Text>
+
 			<Text id="descWelcome">
 				You are docked at a habitat made out of shipping containers. Children
 				bounce off the bulkheads in zero-G while maintenance workers repair
@@ -1253,6 +1251,10 @@
 				"We don't get many pilgrims visiting around here. Why don't you give
 				us some of your worldly possessions; they won't do you much good at
 				the Core, or wherever you're trying to get."
+			</Text>
+
+			<Text id="rumor.intro">
+				The station master grabs you and speaks softly in your ear:\n\n
 			</Text>
 		</Language>
 	</StationType>
@@ -1987,16 +1989,12 @@
 		</Panes>
 	</DockScreen>
 
-	<!-- Donate Item to Container Habitat
-
-		gPrevScreen: Must be set to the name/UNID of the screen to
-				navigate to when done.
-		gPrevPane: Must be set to the name of the pane to navigate
-				to when done.
-		-->
+	<!-- Donate Item to Container Habitat -->
 
 	<DockScreen UNID="&dsContainerHabitatDonateItem;"
 			type=				"itemPicker"
+			nestedScreen=		"true"
+			inherit=			"&dsDockScreenBase;"
 			>
 
 		<ListOptions
@@ -2005,31 +2003,34 @@
 			/>
 
 		<Panes>
-			<Default>
+			<Default descID="descDonateWhat">
 				<OnPaneInit>
-					(block Nil
-						(setq gItem (scrGetItem gScreen))
-						(setq gMaxCount (itmGetCount gItem))
-						(scrSetDesc gScreen "\"What do you want to give us?\"")
-						)
+					(scrEnableAction gScreen 'actionDonateThisItem (scrGetItem gScreen))
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="Donate this Item" default="1" key="D">
-						(switch
-							(gr gMaxCount 1)
-								(scrShowPane gScreen "Quantity")
+					<Action id="actionDonateThisItem" default="1">
+						(block (
+							(theItem (scrGetItem gScreen))
+							(maxCount (itmGetCount theItem))
+							)
+							(switch
+								(gr maxCount 1)
+									(scrShowPane gScreen 'Quantity)
 
-							(eq gMaxCount 1)
 								(block Nil
-									(setq gItem (scrRemoveItem gScreen 1))
-									(scrShowScreen gScreen "&dsContainerHabitatReward;" "Donate")
+									(setq theItem (scrRemoveItem gScreen 1))
+									(scrExitScreen gScreen)
+									(scrShowScreen gScreen &dsContainerHabitatReward; {
+										donatedItem: theItem
+										})
 									)
+								)
 							)
 					</Action>
 
-					<Action name="Cancel" cancel="1" key="C">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionCancel" cancel="1">
+						<Exit/>
 					</Action>
 				</Actions>					
 			</Default>
@@ -2038,183 +2039,173 @@
 					showCounter=	"true">
 
 				<OnPaneInit>
-					(block Nil
-						(scrSetDesc gScreen (cat "\"How many " (itmGetName gItem 0x02) " do you want to give us?\""))
-						(scrSetCounter gScreen gMaxCount)
+					(block (
+						(theItem (scrGetItem gScreen))
+						)
+						(scrSetDescTranslate gScreen 'descDonateQuantity { items: (itmGetName theItem 'plural) })
+						(scrSetCounter gScreen (itmGetCount theItem))
 						)
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="Donate" default="1" key="D">
-						(block (count)
-							(setq count (scrGetCounter gScreen))
-							(if (gr count gMaxCount)
-								(scrSetCounter gScreen gMaxCount)
+					<Action id="actionDonate" default="1">
+						(block (
+							(theItem (scrGetItem gScreen))
+							(maxCount (itmGetCount theItem))
+							(count (scrGetCounter gScreen))
+							)
+							(switch
+								(gr count maxCount)
+									(scrSetCounter gScreen maxCount)
+
 								(block Nil
-									(setq gItem (scrRemoveItem gScreen count))
-									(scrShowScreen gScreen "&dsContainerHabitatReward;" "Donate")
+									(setq theItem (scrRemoveItem gScreen count))
+									(scrExitScreen gScreen)
+									(scrShowScreen gScreen &dsContainerHabitatReward; {
+										donatedItem: theItem
+										})
 									)
 								)
 							)
 					</Action>
 
-					<Action name="Cancel" cancel="1" key="C">
-						<ShowPane pane="Default"/>
+					<Action id="actionCancel" cancel="1">
+						(scrShowPane gScreen 'Default)
 					</Action>
-
 				</Actions>
 			</Quantity>
-
 		</Panes>
 
+		<Language>
+			<String id="descDonateWhat">"What do you want to give us?"</String>
+			<String id="descDonateQuantity">"How many %items% do you want to give us?"</String>
+		</Language>
 	</DockScreen>
 
-	<DockScreen UNID="&dsContainerHabitatReward;">
+	<DockScreen UNID="&dsContainerHabitatReward;"
+			nestedScreen=		"true"
+			inherit=			"&dsDockScreenBase;"
+			>
+
+		<OnScreenInit>
+			(scrSetData gScreen 'donatedItem (or (@ gData 'donatedItem) gItem))
+		</OnScreenInit>
+
 		<Panes>
-			<Donate>
+			<Default>
 				<OnPaneInit>
-					(block (table entry criteria totalValue)
-						; Look for the entry in the donation table
+					(block (
+						(theItem (scrGetData gScreen 'donatedItem))
 
-						(setq table (objGetStaticData gSource "DonationTable"))
-						(setq entry Nil)
-						(enumwhile table (not entry) thisEntry
-							(switch
-								; If the criteria in the table is Nil, then we always match. This
-								; is for the last (default) entry.
-								(not (setq criteria (item thisEntry 0)))
-									(setq entry thisEntry)
+						;	Look for the entry in the donation table
+						(table (objGetStaticData gSource 'DonationTable))
+						(entry (match table thisEntry
+							(or
+								;	If the criteria in the table is Nil, then we always match. This
+								;	is for the last (default) entry.
+								(not (@ thisEntry 0))
 
-								; If the criteria is an integer, then we see if this is the UNID
-								; of the item.
-								(isint criteria)
-									(if (eq (itmGetType gItem) criteria)
-										(setq entry thisEntry)
-										)
+								;	If the criteria is an integer, then we see if this is the UNID
+								;	of the item.
+								(= (itmGetType theItem) (@ thisEntry 0))
 
-								; If the criteria matches, then we have an entry
-								(itmMatches gItem criteria)
-									(setq entry thisEntry)
+								;	If the criteria matches, then we have an entry
+								(itmMatches theItem (@ thisEntry 0))
 								)
-							)
+							))
 
-						; Deal with the entry that we found
+						(totalValue (* (objGetBuyPrice gSource theItem) (itmGetCount theItem)))
 
-						(setq gResult (item entry 2))
+						(result (@ entry 2))
+						incPoints
+						)
 
-						; Calculate how valuable the donation was
-						
+						;	Calculate how valuable the donation was
 						(switch
-							; If the player donated rotted food, then we're insulted
-							(and (itmMatches gItem "* +FreshFood;") (eq (objGetBuyPrice gSource gItem) 0))
+							;	If the player donated rotted food, then we're insulted
+							(and (itmMatches theItem "* +FreshFood;") (= totalValue 0))
 								(block Nil
-									(setq gResult 'rottedFood)
-									(setq gResultValue Nil)
+									(objSetTypeData gSource 'donationPoints 0)
+									(setq result 'rottedFood)
+									(setq incPoints Nil)
 									)
-							
-							; If 0, then we get result regardless of quantity
-							(eq (item entry 1) 0)
-								(setq gResultValue Nil)
 
-							; If -1, then each item counts for +1 donation points
-							(eq (item entry 1) -1)
-								(setq gResultValue (itmGetCount gItem))
+							;	If 0, then we get result regardless of quantity
+							(eq (@ entry 1) 0)
+								(setq incPoints Nil)
 
-							; Otherwise, depends on the value of the item
-							(block Nil
-								(setq totalValue (multiply (objGetBuyPrice gSource gItem) (itmGetCount gItem)))
-								(setq gResultValue (divide totalValue (item entry 1)))
-								)
-							)
-							
-						; Accumulate donation points
-						
-						(block (donationPoints)
-							(setq donationPoints (objGetGlobalData gSource "donationPoints"))
-							(if (not donationPoints) (setq donationPoints 0))
+							;	If -1, then each item counts for +1 donation points
+							(eq (@ entry 1) -1)
+								(setq incPoints (itmGetCount theItem))
 
-							(if gResultValue
-								(setq donationPoints (add donationPoints gResultValue))
-								)
-
-							(objSetGlobalData gSource "donationPoints" donationPoints)
+							;	Otherwise, depends on the value of the item
+							(setq incPoints (divide totalValue (@ entry 1)))
 							)
 
-						; Deal with the result appropriately
+						(if (= incPoints 0)
+							(setq result 'notEnough)
+							)
+						(scrSetData gScreen 'result result)
 
+						;	Accumulate donation points
+						(typIncData (objGetType gSource) 'donationPoints incPoints)
+
+						;	Deal with the result appropriately
 						(switch
-							(and gResultValue (eq gResultValue 0))
-								(block Nil
-									(setq desc "\"Thanks, that's something we need more of around here.\"")
-									(setq gResult 'thanksForNothing)
-									)
+							(= result 'rottedFood)
+								(scrSetDescTranslate gScreen 'descDonateInsulted)
 
-							(eq gResult 'info)
-								(setq desc (cat
-									"\"Thank you, %sir%! We'll put " (itmGetName gItem 0x40) " to good use. Maybe I can help you in return.\""
-									))
-									
-							(eq gResult 'rottedFood)
-								(block Nil
-									(setq desc (cat
-										"\"Kack! What do you think we're going to do with that? Thanks for nothing!\""
-										))
-									(objSetGlobalData gSource "donationPoints" 0)
-									)
+							(= result 'notEnough)
+								(scrSetDescTranslate gScreen 'descDonateNotEnough)
 
-							; Thanks for nothing
-							(block Nil
-								(setq desc (cat
-									"\"Yeah, I guess you won't be needing" 
-									(if (gr (itmGetCount gItem) 1) " them " " that ")
-									"where you're going. Not sure we need"
-									(if (gr (itmGetCount gItem) 1) " them " " it ")
-									"ourselves, but thanks anyway.\""
-									))
-								(setq gResult 'thanksForNothing)
+							(= result 'info)
+								(scrSetDescTranslate gScreen 'descDonateThanks {
+									item: (itmGetName theItem 'demonstrative)
+									})
+
+							;	Thanks for nothing
+							(scrSetDescTranslate gScreen
+								(if (gr (itmGetCount theItem) 1)
+									'descDonateUselessPlural
+									'descDonateUseless
+									)
 								)
 							)
-
-						(scrSetDesc gScreen desc)
 						)
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="Continue" cancel="1" default="1" key="C">
+					<Action id="actionContinue" cancel="1" default="1">
 						(switch
-							(eq gResult 'info)
-								(if (geq (objGetGlobalData gSource "donationPoints") 5)
+							(= (scrGetData gScreen 'result) 'info)
+								(if (geq (objGetTypeData gSource 'donationPoints) 5)
 									(scrShowPane gScreen "RewardInfo")
 									(scrShowPane gScreen "RewardInfoRumors")
 									)
 
-							(scrShowScreen gScreen gPrevScreen gPrevPane)
+							(scrExitScreen gScreen)
 							)
 					</Action>
 				</Actions>
+			</Default>
 
-			</Donate>
-
-			<RewardInfo>
+			<RewardInfo descID="descRewardInfo">
 				<OnPaneInit>
-					(block (donationPoints)
-						(scrSetDesc gScreen (cat
-							"\"I know a thing or two about getting around in this system. What do you need to know?\""
-							))
-
-						(setq donationPoints (objGetGlobalData gSource "donationPoints"))
+					(block (
+						(donationPoints (objGetTypeData gSource 'donationPoints))
+						)
 
 						; Equipment location available after 5 donation points
-						(scrShowAction gScreen 0 (geq donationPoints 5))
+						(scrShowAction gScreen 'actionInfoEquipment (geq donationPoints 5))
 
 						; Centauri warlords info available in Eridani after 10 points
-						(scrShowAction gScreen 1 
+						(scrShowAction gScreen 'actionInfoCentauriBase
 							(and (geq donationPoints 10) (eq (sysGetNode) 'SE))
 							)
 
 						; Arco Vaughn info available after 20 points and only in SE or if he
 						; is still alive
-						(scrShowAction gScreen 2 
+						(scrShowAction gScreen 'actionInfoArcoVaughn
 							(and (geq donationPoints 20)
 								(eq (sysGetNode) 'SE)
 								(not (eq (typGetGlobalData &scArcoVaughnHeavyRaider; "status") 'destroyed))
@@ -2222,7 +2213,7 @@
 							)
 
 						; Korolov station info available after 5 points if past SE
-						(scrShowAction gScreen 3
+						(scrShowAction gScreen 'actionInfoKorolov
 							(and (geq donationPoints 5)
 								(not (eq (sysGetNode) 'SE))
 								(leq (sysGetLevel) 3)
@@ -2232,24 +2223,24 @@
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="&quot;I need better equipment.&quot;" key="e">
+					<Action id="actionInfoEquipment">
 						(scrShowPane gScreen "RewardInfoEquipment")
 					</Action>
 
-					<Action name="&quot;Where are the Centauri warlords?&quot;" key="C">
+					<Action id="actionInfoCentauriBase">
 						(scrShowPane gScreen "RewardInfoCentauriBase")
 					</Action>
 
-					<Action name="&quot;Where is Arco Vaughn?&quot;" key="A">
+					<Action id="actionInfoArcoVaughn">
 						(scrShowPane gScreen "RewardInfoArcoVaughn")
 					</Action>
 
-					<Action name="&quot;Is there a Korolov station nearby?&quot;" key="K">
+					<Action id="actionInfoKorolov">
 						(scrShowPane gScreen "RewardInfoKorolov")
 					</Action>
 
-					<Action name="&quot;Nevermind, I'm all set.&quot;" key="N" cancel="1">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionNevermind" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 				</Actions>
 			</RewardInfo>
@@ -2272,8 +2263,8 @@
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="Continue" cancel="1" default="1" key="C">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionContinue" default="1" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 				</Actions>
 			</RewardInfoRumors>
@@ -2367,26 +2358,26 @@
 						(scrSetDesc gScreen desc)
 
 						; Enable disable buttons
-						(scrShowAction gScreen 0 aEvent)
-						(scrShowAction gScreen 1 aEvent)
-						(scrShowAction gScreen 2 (not aEvent))
+						(scrShowAction gScreen 'actionCoordinates aEvent)
+						(scrShowAction gScreen 'actionNevermind aEvent)
+						(scrShowAction gScreen 'actionContinue (not aEvent))
 						)
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="&quot;Give me the coordinates, please!&quot;" key="C" default="1">
+					<Action id="actionCoordinates" default="1">
 						(block Nil
 							(objFireEvent gSource aEvent)
 							(scrShowPane gScreen "RewardInfoDone")
 							)
 					</Action>
 
-					<Action name="&quot;Nevermind, I'm all set.&quot;" key="N" cancel="1">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionNevermind" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 
-					<Action name="Continue" cancel="1" default="1" key="C">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionContinue" default="1" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 				</Actions>
 			</RewardInfoEquipment>
@@ -2415,27 +2406,26 @@
 						(scrSetDesc gScreen desc)
 
 						; Enable disable buttons
-						(scrShowAction gScreen 0 aEvent)
-						(scrShowAction gScreen 1 aEvent)
-						(scrShowAction gScreen 2 (not aEvent))
+						(scrShowAction gScreen 'actionCoordinates aEvent)
+						(scrShowAction gScreen 'actionNevermind aEvent)
+						(scrShowAction gScreen 'actionContinue (not aEvent))
 						)
-
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="&quot;Give me the coordinates, please!&quot;" key="C" default="1">
+					<Action id="actionCoordinates" default="1">
 						(block Nil
 							(objFireEvent gSource aEvent)
 							(scrShowPane gScreen "RewardInfoDone")
 							)
 					</Action>
 
-					<Action name="&quot;Nevermind, I'm all set.&quot;" key="N" cancel="1">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionNevermind" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 
-					<Action name="Continue" cancel="1" default="1" key="C">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionContinue" default="1" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 				</Actions>
 			</RewardInfoCentauriBase>
@@ -2474,8 +2464,8 @@
 
 						; Enable disable buttons
 						(scrShowAction gScreen 0 aEvent)
-						(scrShowAction gScreen 1 aEvent)
-						(scrShowAction gScreen 2 (not aEvent))
+						(scrShowAction gScreen 'actionNevermind aEvent)
+						(scrShowAction gScreen 'actionContinue (not aEvent))
 						)
 				</OnPaneInit>
 
@@ -2487,12 +2477,12 @@
 							)
 					</Action>
 
-					<Action name="&quot;Nevermind, I'm all set.&quot;" key="N" cancel="1">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionNevermind" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 
-					<Action name="Continue" cancel="1" default="1" key="C">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionContinue" default="1" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 				</Actions>
 			</RewardInfoArcoVaughn>
@@ -2525,8 +2515,8 @@
 
 						; Enable disable buttons
 						(scrShowAction gScreen 0 aEvent)
-						(scrShowAction gScreen 1 aEvent)
-						(scrShowAction gScreen 2 (not aEvent))
+						(scrShowAction gScreen 'actionNevermind aEvent)
+						(scrShowAction gScreen 'actionContinue (not aEvent))
 						)
 				</OnPaneInit>
 
@@ -2538,12 +2528,12 @@
 							)
 					</Action>
 
-					<Action name="&quot;Nevermind, I'm all set.&quot;" key="N" cancel="1">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionNevermind" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 
-					<Action name="Continue" cancel="1" default="1" key="C">
-						(scrShowScreen gScreen gPrevScreen gPrevPane)
+					<Action id="actionContinue" default="1" cancel="1">
+						(scrExitScreen gScreen)
 					</Action>
 				</Actions>
 			</RewardInfoKorolov>
@@ -2560,12 +2550,37 @@
 				</OnPaneInit>
 
 				<Actions>
-					<Action name="Continue" key="C" default="1" cancel="1">
+					<Action id="actionContinue" default="1" cancel="1">
 						<Exit/>
 					</Action>
 				</Actions>
 			</RewardInfoDone>
 		</Panes>
+
+		<Language>
+			<String id="actionInfoEquipment">"I need better [e]quipment."</String>
+			<String id="actionInfoCentauriBase">"Where are the [C]entauri warlords?"</String>
+			<String id="actionInfoArcoVaughn">"Where is [A]rco Vaughn?"</String>
+			<String id="actionInfoKorolov">"Is there a [K]orolov station nearby?"</String>
+			<String id="actionCoordinates">"Give me the [c]oordinates, please!"</String>
+			<String id="actionNevermind">"[N]evermind, I'm all set."</String>
+
+			<String id="descDonateNotEnough">"Thanks, that's something we need more of around here."</String>
+			<String id="descDonateThanks">"Thank you, %sir%! We'll put %item% to good use. Maybe I can help you in return."</String>
+			<String id="descDonateInsulted">"Kack! What do you think we're going to do with that? Thanks for nothing!"</String>
+			<Text id="descDonateUseless">
+				"Yeah, I guess you won't be needing that where you're going.
+				Not sure we need it ourselves, but thanks anyway."
+			</Text>
+			<Text id="descDonateUselessPlural">
+				"Yeah, I guess you won't be needing them where you're going.
+				Not sure we need them ourselves, but thanks anyway."
+			</Text>
+			<Text id="descRewardInfo">
+				"I know a thing or two about getting around in this system.
+				What do you need to know?"
+			</Text>
+		</Language>
 	</DockScreen>
 
 <!-- BASIC COMMONWEALTH RULES

--- a/TransCore/Commonwealth.xml
+++ b/TransCore/Commonwealth.xml
@@ -930,30 +930,28 @@
 
 			<OnContractQuery>True</OnContractQuery>
 
-			<GetRumors>
-				(if (= gSource (@ gData 'stationObj))
-					(append
-						(rpgRumorAdd 'commonwealthHabitat (make 'sequence 4))
+			<GetGlobalRumors>
+				(append
+					(rpgRumorAdd 'commonwealthHabitat (make 'sequence 4))
 
-						(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
-							(rpgRumorAdd 'commonwealthHabitat 'pilgrim)
-							(rpgRumorAdd 'commonwealthHabitat 'freelancer)
-							)
+					(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+						(rpgRumorAdd 'commonwealthHabitat 'pilgrim)
+						(rpgRumorAdd 'commonwealthHabitat 'freelancer)
+						)
 
-						(rpgRumorAdd 'commonwealthHabitat
-							(switch
-								(= (objGetType gPlayerShip) &scSapphirePlayer;)	'sapphire
-								(= (objGetType gPlayerShip) &scEI100XPlayer;)	'ei100x
-								(= (objGetType gPlayerShip) &scWolfenPlayer;)	'wolfen
-																				'other
-								)
-							Nil
-							Nil
-							{	shipName: (objGetName gPlayerShip)	}
+					(rpgRumorAdd 'commonwealthHabitat
+						(switch
+							(= (objGetType gPlayerShip) &scSapphirePlayer;)	'sapphire
+							(= (objGetType gPlayerShip) &scEI100XPlayer;)	'ei100x
+							(= (objGetType gPlayerShip) &scWolfenPlayer;)	'wolfen
+																			'other
 							)
+						Nil
+						Nil
+						{	shipName: (objGetName gPlayerShip)	}
 						)
 					)
-			</GetRumors>
+			</GetGlobalRumors>
 		</Events>
 
 		<DockScreens>

--- a/TransCore/Commonwealth.xml
+++ b/TransCore/Commonwealth.xml
@@ -830,272 +830,12 @@
 		</Language>
 	</StationType>
 	
-	<!-- Mission: Destroy Threat to Commonwealth Habitat
-	
-	EXTRA DATA
-	
-	reward:				Reward (in credits) for completing mission
-	targetID:			Id of station to destroy
-	targetType:			One of:
-							'centauriWarlords
-							'miscEnemy
-
-	-->
-	
-	<MissionType UNID="&msDestroyThreatToSlums;"
-			name=				"Destroy Threat to Commonwealth Habitat"
-			attributes=			"commonwealth, commonwealthHabitat"
-
-			level=				"1-4"
-			scope=				"system"
-
-			>
-		<Events>
-			<OnCreate>
-				; Called when mission object is created. This adds the mission
-				; to the list of available missions, but it does not necessarily
-				; start the mission.
-				;
-				; The script may call msnDestroy to abort creation of the mission.
-				;
-				; gSource is mission object
-				; gData is arbitrary data passed in to msnCreate
-				; aOwnerObj is the object that created the mission (or nil)
-				
-				(block (enemyStations)
-				
-					(switch
-					
-						; Get a list of enemy stations in the region. If we cannot find any
-						; suitable targets then we don't have a mission.
-						
-						(not (setq enemyStations (sysFindObject aOwnerObj "TAE +populated; -uncharted; N:450;")))
-							(msnDestroy gSource)
-							
-						; Otherwise we can create a mission
-						
-						(block (targetObj)
-						
-							; Pick a random enemy station to destroy
-							(setq targetObj (seededRandom (objGetDestiny aOwnerObj) enemyStations))
-							
-							; Remember it
-							(msnSetData gSource 'targetID (objGetID targetObj))
-							
-							; Register for events so we know when the target is destroyed
-							(msnRegisterForEvents gSource targetObj)
-
-							; Remember the type of enemy
-							(switch
-								(objHasAttribute targetObj "centauriWarlords")
-									(msnSetData gSource 'targetType 'centauriWarlords)
-									
-								(msnSetData gSource 'targetType 'miscEnemy)
-								)
-								
-							; Compute reward
-							(msnSetData gSource 'reward (add 200 (multiply (objGetLevel targetObj) 100)))
-							)
-						)
-					)
-			</OnCreate>
-
-			<OnAccepted>
-				; Called if the player accepts the mission. The mission is 
-				; already running (OnStarted has been called).
-				;
-				; gSource is mission object
-
-			</OnAccepted>
-			
-			<OnDeclined>
-				; Called if the player rejects the mission. The mission is already
-				; running (OnStarted has been called).
-				;
-				; gSource is mission object.
-
-			</OnDeclined>
-
-			<OnStarted>
-				; Called when the mission starts. This is called if the mission
-				; starts running (either because the player accepted or some other
-				; reason).
-				;
-				; gSource is mission object.
-
-			</OnStarted>
-			
-			<OnSetPlayerTarget>
-				; Called to refresh the player's target. Always called right after
-				; the player accepts the mission. May be called at other times
-				; (e.g., after the player returns to the system).
-				;
-				; gSource is mission object
-				; aReason is:
-				;		'accepted: Mission has been accepted
-				;		'debriefed: Player has been debriefed
-				;		'failure: Mission failed
-				;		'inProgress: Player visited station while mission in progress
-				;		'newSystem: Player is in a new system
-				;		'success: Mission completed successfully
-				
-				(block (targetObj)
-					(switch
-						; If we just got debriefed then we clear our targets.
-
-						(eq aReason 'debriefed)
-							(shpCancelOrders gPlayerShip)
-
-						; If the mission is complete, then we point towards the 
-						; owner station.
-
-						(msnGetProperty gSource 'isCompleted)
-							(if (setq targetObj (objGetObjByID (msnGetProperty gSource 'ownerID)))
-								(block Nil
-									(shpCancelOrders gPlayerShip)
-									(shpOrder gPlayerShip 'dock targetObj)
-									)
-								)
-
-						; Otherwise, we point towards the target
-
-						(if (setq targetObj (objGetObjByID (msnGetData gSource 'targetID)))
-							(block Nil
-								(shpCancelOrders gPlayerShip)
-								(shpOrder gPlayerShip 'attack targetObj)
-								)
-							)
-						)
-					)
-			</OnSetPlayerTarget>
-			
-			<OnObjDestroyed>
-				(switch
-					(eq (objGetID aObjDestroyed) (msnGetData gSource 'targetID))
-						(msnSuccess gSource)
-					)
-			</OnObjDestroyed>
-			
-			<OnCompleted>
-				; Called when the mission ends (generally because msnSuccess or
-				; msnFailure were called).
-				;
-				; gSource is mission object
-				; gData is arbitrary data passed in to msnSuccess or msnFailure
-				; aReason is:
-				;		'failure: Mission failed
-				;		'success: Mission completed successfully
-				
-			</OnCompleted>
-			
-			<OnReward>
-				; Called by msnReward, generally during debrief.
-				;
-				; gSource is mission object
-				; gData is data passed to msnReward
-
-				(intMissionRewardPayment (msnGetData gSource 'reward))
-			</OnReward>
-			
-			<OnDestroy>
-				; Called when mission object is destroyed (after mission ends)
-				;
-				; gSource is mission object
-				;
-				; NOTE: No need to unregister for events because we automatically
-				; unregister when the mission is complete.
-
-			</OnDestroy>
-		</Events>
-		
-		<Language>
-			<Text id="Name">
-				"Destroy Threat to Commonwealth Habitat"
-			</Text>
-			<Text id="Summary">
-				(cat
-					"Your mission is to destroy " (objGetName (objGetObjByID (msnGetData gSource 'targetID)) 0x04) " in the " (sysGetName) " system.\n\n"
-					"System: " (sysGetName) "\n"
-					"Payment: " (msnGetData gSource 'reward) " credits"
-					)
-			</Text>
-			<Text id="Intro">
-
-				The station master stands at his console. Managers and 
-				supervisors swarm around him dealing with various crises. He 
-				turns his attention towards you:
-
-				"We could use your help, %brother%. You've got a ship with a 
-				good punch and we got something that needs punching. We'll pay 
-				you, of course."
-
-			</Text>
-			<Text id="Briefing">
-				(block (
-					(targetObj (objGetObjByID (msnGetData gSource 'targetID)))
-					)
-
-					(switch
-						(eq (msnGetData gSource 'targetType) 'centauriWarlords)
-							(cat
-								"\"A band of Centauri warlords has been harassing this station recently. We've discovered the location of their base and we want you to go there and destroy them. "
-								"If you succeed we'll pay you " (msnGetData gSource 'reward) " credits. Will you help us?\""
-								)
-							
-						(cat
-							"\"" (objGetName targetObj 0x05) " nearby has been attacking us recently. We want you to destroy them! "
-							"If you succeed we'll pay you " (msnGetData gSource 'reward) " credits. Will you help us?\""
-							)
-						)
-					)
-			</Text>
-			<Text id="AcceptReply">
-
-				"Thank you! I knew we could count on you. We'll program the 
-				target into your ship's computer. Just follow the arrow on your 
-				screen and you'll get there. Good luck!"
-
-			</Text>
-			<String id="DeclineReply">
-				"Ah, Hell! What are you doing here then? Stop wasting my time!"
-			</String>
-			<Text id="InProgress">
-
-				"What's wrong? You said you could handle this mission! Get back 
-				out there and finish the job!"
-
-			</Text>
-			<Text id="SuccessDebrief">
-				(cat
-					(switch
-						(eq (msnGetData gSource 'targetType) 'centauriWarlords)
-							"\"Great work! Maybe the warlords will think twice before attacking us again."
-
-						"\"Great work! Now we can live in peace. "
-						)
-					" We've deposited " (msnGetData gSource 'reward) " credits to your account.\""
-					)
-			</Text>
-			<Text id="SuccessMsg">
-				Mission complete!
-			</Text>
-			<String id="AlreadyDebriefed">
-				"Welcome back! Thanks for the great work last time."
-			</String>
-			<String id="Unavailable">
-				"Sorry, there are no missions available."
-			</String>
-		</Language>
-	</MissionType>
-
 	<!-- Commonwealth Slums
 
 	GLOBAL DATA
 
 	lastMissionTime:	Tick on which mission was given to player (Nil if never)
 	totalMissionCount:	Total number of missions that the player has requested
-	missionsCompleted:	Total number of successful missions
-	missionsFailed:		Total number of failures
 
 	-->
 
@@ -1140,55 +880,6 @@
 		</Ships>
 
 		<StaticData>
-			<Rumors>
-				(
-					"\"You got a pretty nice ship there. Did your mom and dad buy it for you?\""
-					"\"Truth is, you gotta approach life philosophically, you know what I mean? You gotta believe that it's all going to work out in the end, or else what's the point?\""
-					"\"Nobody cares. Station needs a carbon scrubber? Get on the waiting list! After the corporate suits get their grilled Icelandic salmon, then they might pay attention to you. Nobody cares.\""
-					(if (eq (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
-						"\"I don't know what you're doing in this backwater system. You wanna get to the Core? Go! What's stopping you? Kids today: they dream big, but they'd rather watch the 3DVs.\""
-						"\"I don't know what you're doing in this backwater system. You wanna see the galaxy? Go! What's stopping you? Kids today: they dream big, but they'd rather watch the 3DVs.\""
-						)
-					"\"A station is not like a starship. If you get into trouble you can always run away. All we can do is sit tight and repair the damage. Takes a special kind of man to live like that.\""
-					(cat "\"How do you like your " (objGetName gPlayerShip 0x00) "? "
-						(switch 
-							(eq (objGetType gPlayerShip) &scSapphirePlayer;)
-								"My daughter's friend had one once. It was beautiful, but not very practical for long voyages.\""
-							(eq (objGetType gPlayerShip) &scEI100XPlayer;)
-								"My son pilots an older 200-series in the Cairn system. He's got it up-armored with polyceramic to protect against pirate attacks.\""
-							(eq (objGetType gPlayerShip) &scWolfenPlayer;)
-								"I knew this guy John Tremaine who flew one in the Militia. They're fast as hell on a whip, but a little flimsy. Hope you've got some good shields on her.\""
-							"I haven't seen a lot of ships like that. Is it hard to get parts for it?\""
-							)
-						)
-					)
-			</Rumors>
-
-			<RumorsSE>
-				(
-					"\"You got a pretty nice ship there. Did your mom and dad buy it for you?\""
-					"\"Truth is, you gotta approach life philosophically, you know what I mean? You gotta believe that it's all going to work out in the end, or else what's the point?\""
-					"\"Nobody cares. Station needs a carbon scrubber? Get on the waiting list! After the corporate suits get their grilled Icelandic salmon, then they might pay attention to you. Nobody cares.\""
-					(if (not (eq (typGetGlobalData &scArcoVaughnHeavyRaider; "status") 'destroyed))
-						"\"The warlords are annoying, but they don't mean much. The only one that bothers me is Arco Vaughn. He's trouble. Someone ought to air him out before things get out of hand, you know?\""
-						"\"Thank heavens that someone finally killed Arco Vaughn. Maybe now the warlords will leave us alone.\""
-						)
-					"\"I don't know what you're doing in this backwater system. You wanna get to the Core? Go! What's stopping you? Kids today: they dream big, but they'd rather watch the 3DVs.\""
-					(if (not (eq (typGetGlobalData &scArcoVaughnHeavyRaider; "status") 'destroyed))
-						"\"It's sad about Raisu station, isn't it? If a corporate fuel station got taken over by Centauri warlords they'd have Admiral Decker himself leading the rescue. But no one cares about a poor, backwater station, I guess.\""
-						"\"It's shame what Raisu station had to go through, isn't it? If a corporate station had been occupied by warlords, they'd have sent Admiral Decker himself to lead the rescue. But no one cares about a poor, backwater station, I guess.\""
-						)
-					(if (not (eq (typGetGlobalData &scArcoVaughnHeavyRaider; "status") 'destroyed))
-						"\"If you're looking for Arco Vaughn, go to Raisu station: the station master there will help you out. But first you gotta convince her that you're serious.\""
-						"\"I hear that Arco Vaughn is finally dead. No one will mourn him. I really feel for Erica and her team at Raisu\x97they went through hell.\""
-						)
-					(if (not (eq (typGetGlobalData &scArcoVaughnHeavyRaider; "status") 'destroyed))
-						"\"If you need help against Arco Vaughn the station master at Raisu station will help you. But you'll have to prove that you're serious. Take out a few Centauri stations and you might convince her.\""
-						"\"We're all glad that Arco Vaughn is dead. I heard someone from Raisu station finally had enough and decided to chase him down."\""
-						)
-					)
-			</RumorsSE>
-
 			<RumorsBA>
 				(
 					(cat "\"What's your favorite weapon? Personally I favor "
@@ -1217,18 +908,19 @@
 
 		<Events>
 			<GetGlobalAchievements>
-				(block (theList)
-					(if (gr (typGetGlobalData &stCommonwealthSlums; 'totalMissionCount) 0)
-						(setq theList (list
+				(block (
+					(successList (plyGetKeyEventStat gPlayer 'missionSuccess Nil "* +commonwealthHabitat;"))
+					(failureList (plyGetKeyEventStat gPlayer 'missionFailure Nil "* +commonwealthHabitat;"))
+					)
+					(if (or successList failureList)
+						(list
 							(list
-								"Commonwealth habitat missions"
-								(intMissionAchievementString (typGetGlobalData &stCommonwealthSlums; 'missionsCompleted) (typGetGlobalData &stCommonwealthSlums; 'missionsFailed))
-								"missions &amp; activities"
+								(typTranslate &stCommonwealthSlums; 'missions)
+								(rpgMissionAchievementString (count successList) (count failureList))
+								(typTranslate &unidCommonText; 'missionsAndActivities)
 								)
-							))
+							)
 						)
-						
-					theList
 					)
 			</GetGlobalAchievements>
 
@@ -1238,18 +930,30 @@
 
 			<OnContractQuery>True</OnContractQuery>
 
-			<OnMissionAccepted>
-				(typIncGlobalData &stCommonwealthSlums; 'totalMissionCount)
-			</OnMissionAccepted>
+			<GetRumors>
+				(if (= gSource (@ gData 'stationObj))
+					(append
+						(rpgRumorAdd 'commonwealthHabitat (make 'sequence 4))
 
-			<OnMissionCompleted>
-				(if (msnGetProperty aMissionObj 'isActive)
-					(if (eq aReason 'success)
-						(typIncGlobalData &stCommonwealthSlums; 'missionsCompleted)
-						(typIncGlobalData &stCommonwealthSlums; 'missionsFailed)
+						(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+							(rpgRumorAdd 'commonwealthHabitat 'pilgrim)
+							(rpgRumorAdd 'commonwealthHabitat 'freelancer)
+							)
+
+						(rpgRumorAdd 'commonwealthHabitat
+							(switch
+								(= (objGetType gPlayerShip) &scSapphirePlayer;)	'sapphire
+								(= (objGetType gPlayerShip) &scEI100XPlayer;)	'ei100x
+								(= (objGetType gPlayerShip) &scWolfenPlayer;)	'wolfen
+																				'other
+								)
+							Nil
+							Nil
+							{	shipName: (objGetName gPlayerShip)	}
+							)
 						)
 					)
-			</OnMissionCompleted>
+			</GetRumors>
 		</Events>
 
 		<DockScreens>
@@ -1262,52 +966,12 @@
 
 						<Actions>
 							<Action id="actionMainHall" default="1">
-								(block (lastMissionTime missionInterval theMission)
-									; Figure out the last time that a habitat gave out a mission
-									(setq lastMissionTime (objGetGlobalData gSource "lastMissionTime"))
-
-									; Time between missions (5400-8990 or 3-5 real minutes)
-									(setq missionInterval (add 5400 (multiply (objGetDestiny gSource) 10)))
-
-									(switch
-										; If we have an active mission, then show it
-										(setq theMission (@ (msnFind gSource "aS") 0))
-											(scrShowScreen gScreen &dsRPGMission;
-												{
-												missionObj: theMission
-												})
-
-										; If the player has an active mission from some other station, then
-										; no new mission
-
-										(msnFind Nil "a +commonwealthHabitat;")
-											(scrShowPane gScreen "Rumors")
-
-										; If its not time for a new mission, then rumors
-										(and lastMissionTime
-												(gr (add lastMissionTime missionInterval) (unvGetTick)))
-											(scrShowPane gScreen "Rumors")
-
-										; If we've already gotten six missions, then no more missions
-										(geq (objGetGlobalData gSource "totalMissionCount") 6)
-											(scrShowPane gScreen "Rumors")
-
-										; If we have an open mission or if we can create a mission then
-										; show it.
-										(or (setq theMission (@ (msnFind gSource "oS") 0))
-												(setq theMission (msnCreate (typFind "n +commonwealthHabitat;") gSource)))
-											(block Nil
-												(objSetGlobalData gSource "lastMissionTime" (unvGetTick))
-												(scrShowScreen gScreen &dsRPGMission;
-													{
-													missionObj: theMission
-													})
-												)
-
-										; Otherwise, just rumors
-										(scrShowPane gScreen "Rumors")
-										)
-									)
+								(rpgMissionAssignment {
+									missionCriteria: "n +commonwealthHabitat;"
+									maxActive: 1
+									intervalPerType: (+ 5400 (* (objGetDestiny gSource) 10))
+									noMissionTextID: 'descNoMissions
+									})
 							</Action>
 
 							<Action id="actionUndock" cancel="1">
@@ -1315,37 +979,8 @@
 							</Action>
 						</Actions>
 					</Default>
-
-					<Rumors>
-						<OnPaneInit>
-							(block (rumorTable)
-								(switch
-									(eq (sysGetNode) 'SE)
-										(setq rumorTable "RumorsSE")
-
-									(eq (sysGetNode) 'BA)
-										(setq rumorTable "RumorsBA")
-
-									(setq rumorTable "Rumors")
-									)
-
-								(scrSetDesc gScreen
-									(cat "The station master is working at his console. He stops to chat:\n\n"
-										(eval (intRandomMessage gSource rumorTable))
-										)
-									)
-								)
-						</OnPaneInit>
-
-						<Actions>
-							<Action id="actionContinue" default="1" cancel="1">
-								(scrShowPane gScreen "Default")
-							</Action>
-						</Actions>
-					</Rumors>
 				</Panes>
 			</Main>
-
 		</DockScreens>
 
 		<DockingPorts>
@@ -1361,12 +996,73 @@
 
         <Language>
 			<Text id="descWelcome">
+
 				The loud voices of a packed multitude bounce off every bulkhead and
 				corridor in the station. Old air scrubbers pump a thin, odorous
 				breeze out of rusty vents. Discarded packets of Salmonite and Red
 				Nebula beer huddle in the corner.
 
 				Welcome to %objName%!
+
+			</Text>
+			<Text id="descNoMissions">
+
+				The colony supervisor is working at his station. The comms channels
+				are quiet and he stops to chat:
+
+				"It's calm now, but I've been hearing a lot of military chatter lately."
+
+			</Text>
+			<Text id="missions">Commonwealth habitat missions</Text>
+
+			<Text id="rumor.intro">
+				The station master is working at his console. He stops to chat:\n\n
+			</Text>
+			<String id="rumor.commonwealthHabitat.1">
+				"You got a pretty nice ship there. Did your mom and dad buy it for you?"
+			</String>
+			<Text id="rumor.commonwealthHabitat.2">
+				"Truth is, you gotta approach life philosophically, you know what I mean?
+				You gotta believe that it's all going to work out in the end, or else
+				what's the point?"
+			</Text>
+			<Text id="rumor.commonwealthHabitat.3">
+				"Nobody cares. Station needs a carbon scrubber? Get on the waiting list!
+				After the corporate suits get their grilled Icelandic salmon, then they
+				might pay attention to you. Nobody cares."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.4">
+				"A station is not like a starship. If you get into trouble you can always
+				run away. All we can do is sit tight and repair the damage. Takes a
+				special kind of man to live like that."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.pilgrim">
+				"I don't know what you're doing in this backwater system. You wanna get
+				to the Core? Go! What's stopping you? Kids today: they dream big, but
+				they'd rather watch the 3DVs."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.freelancer">
+				"I don't know what you're doing in this backwater system. You wanna see
+				the galaxy? Go! What's stopping you? Kids today: they dream big, but
+				they'd rather watch the 3DVs."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.sapphire">
+				"How do you like your %shipName%? My daughter's friend had one once.
+				It was beautiful, but not very practical for long voyages."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.ei100x">
+				"How do you like your %shipName%? My son pilots an older 200-series	in the
+				Cairn system. He's got it up-armored with polyceramic to protect against
+				pirate attacks."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.wolfen">
+				"How do you like your %shipName%? I knew this guy John Tremaine who flew
+				one in the Militia. They're fast as hell on a whip, but a little flimsy.
+				Hope you've got some good shields on her."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.other">
+				"How do you like your %shipName%? I haven't seen a lot of ships like that.
+				Is it hard to get parts for it?"
 			</Text>
         </Language>
 	</StationType>

--- a/TransCore/CommonwealthMetropolis.xml
+++ b/TransCore/CommonwealthMetropolis.xml
@@ -315,6 +315,7 @@
 								(rpgMissionAssignment {
 									missionCriteria: (cat "n +commonwealthPub; =" (sysGetLevel) ";")
 									noMissionTextID: 'descNoRumors
+									actionDoneID: 'actionLeave
 									maxPerStation: 1
 									})
 								)

--- a/TransCore/CommonwealthMining.xml
+++ b/TransCore/CommonwealthMining.xml
@@ -362,7 +362,7 @@
 							(list
 								"Mining colony missions"
 								(rpgMissionAchievementString (count successList) (count failureList))
-								"missions &amp; activities"
+								(typTranslate &unidCommonText; 'missionsAndActivities)
 								)
 							)
 						)
@@ -372,7 +372,11 @@
 			<GetRumors>
 				(append
 					(rpgRumorAdd 'commonwealthPub 1 20 'scan {station: (objGetName gSource)})
+					)
+			</GetRumors>
 
+			<GetGlobalRumors>
+				(append
 					(rpgRumorAdd 'commonwealthMining (make 'sequence 15))
 
 					(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
@@ -380,7 +384,7 @@
 						(rpgRumorAdd 'commonwealthMining 'freelancer)
 						)
 					)
-			</GetRumors>
+			</GetGlobalRumors>
 
 			<OnContractGenerate>
 				(intGenerateMiningRequestContract1)

--- a/TransCore/CommonwealthMission01.xml
+++ b/TransCore/CommonwealthMission01.xml
@@ -114,34 +114,7 @@
 				;		'newSystem: Player is in a new system
 				;		'success: Mission completed successfully
 
-				(block (targetObj)
-					(switch
-						; If we just got debriefed then we clear our targets.
-
-						(eq aReason 'debriefed)
-							(shpCancelOrders gPlayerShip)
-
-						; If the mission is complete, then we point towards the
-						; owner station.
-
-						(msnGetProperty gSource 'isCompleted)
-							(if (setq targetObj (objGetObjByID (msnGetProperty gSource 'ownerID)))
-								(block Nil
-									(shpCancelOrders gPlayerShip)
-									(shpOrder gPlayerShip 'dock targetObj)
-									)
-								)
-
-						; Otherwise, we point towards the target
-
-						(if (setq targetObj (objGetObjByID (msnGetData gSource 'targetID)))
-							(block Nil
-								(shpCancelOrders gPlayerShip)
-								(shpOrder gPlayerShip 'attack targetObj)
-								)
-							)
-						)
-					)
+				(rpgSetTarget gSource aReason (objGetObjByID (msnGetData gSource 'targetID)))
 			</OnSetPlayerTarget>
 
 			<OnObjDestroyed>
@@ -169,11 +142,13 @@
 				; gSource is mission object
 				; gData is data passed to msnReward
 
-				(intMissionRewardPayment (msnGetData gSource 'reward))
+				(rpgMissionRewardPayment (msnGetData gSource 'reward))
 			</OnReward>
 
 			<OnDestroy>
-				; Called when mission object is destroyed (after mission ends)
+				; Called when mission object is destroyed (generally only non-player
+				; missions are removed when the player changes system. Player
+				; missions are not normally destroyed)
 				;
 				; gSource is mission object
 				;
@@ -184,15 +159,42 @@
 		</Events>
 
 		<Language>
-			<Text id="Name">
-				"Destroy Threat to Commonwealth Habitat"
-			</Text>
+			<!-- Code Points -->
+
 			<Text id="Summary">
 				(cat
-					"Your mission is to destroy " (objGetName (objGetObjByID (msnGetData gSource 'targetID)) 0x04) " in the " (sysGetName) " system.\n\n"
-					"System: " (sysGetName) "\n"
-					"Payment: " (msnGetData gSource 'reward) " credits"
+					(msnTranslate gSource 'descSummary {
+						targetName: (objGetName (objGetObjByID (msnGetData gSource 'targetID)) 'article)
+						systemName: (sysGetName)
+						})
+					"\n\n"
+					(typTranslate &dsRPGMission; 'mission.rewardSummary {
+						systemName: (sysGetName)
+						payment: (fmtCurrency 'credit (msnGetData gSource 'reward))
+						})
 					)
+			</Text>
+
+			<Text id="Briefing">
+				(msnTranslate gSource (cat "Briefing:" (msnGetData gSource 'targetType)) {
+					targetName: (objGetName (objGetObjByID (msnGetData gSource 'targetID)) '(capitalize article))
+					payment: (fmtCurrency 'credit (msnGetData gSource 'reward))
+					})
+			</Text>
+
+			<Text id="SuccessDebrief">
+				(msnTranslate gSource (cat "SuccessDebrief:" (msnGetData gSource 'targetType)) {
+					payment: (fmtCurrency 'credit (msnGetData gSource 'reward))
+					})
+			</Text>
+
+			<!-- Text -->
+
+			<Text id="Name">
+				Destroy Threat to Commonwealth Habitat
+			</Text>
+			<Text id="descSummary">
+				Your mission is to destroy %targetName% in the %systemName% system.
 			</Text>
 			<Text id="Intro">
 
@@ -205,24 +207,19 @@
 				you, of course."
 
 			</Text>
-			<Text id="Briefing">
-				(block (
-					(targetObj (objGetObjByID (msnGetData gSource 'targetID)))
-					)
+			<Text id="Briefing:centauriWarlords">
 
-					(switch
-						(eq (msnGetData gSource 'targetType) 'centauriWarlords)
-							(cat
-								"\"A band of Centauri warlords has been harassing this station recently. We've discovered the location of their base and we want you to go there and destroy them. "
-								"If you succeed we'll pay you " (msnGetData gSource 'reward) " credits. Will you help us?\""
-								)
+				"A band of Centauri warlords has been harassing this station recently.
+				We've discovered the location of their base and we want you to go there
+				and destroy them. If you succeed we'll pay you %payment%. Will you help us?"
 
-						(cat
-							"\"" (objGetName targetObj 0x05) " nearby has been attacking us recently. We want you to destroy them! "
-							"If you succeed we'll pay you " (msnGetData gSource 'reward) " credits. Will you help us?\""
-							)
-						)
-					)
+			</Text>
+
+			<Text id="Briefing:miscEnemy">
+
+				"%targetName% nearby has been attacking us recently. We want you to destroy them!
+				If you succeed we'll pay you %payment% credits. Will you help us?"
+
 			</Text>
 			<Text id="AcceptReply">
 
@@ -240,16 +237,17 @@
 				out there and finish the job!"
 
 			</Text>
-			<Text id="SuccessDebrief">
-				(cat
-					(switch
-						(eq (msnGetData gSource 'targetType) 'centauriWarlords)
-							"\"Great work! Maybe the warlords will think twice before attacking us again."
+			<Text id="SuccessDebrief:centauriWarlords">
 
-						"\"Great work! Now we can live in peace. "
-						)
-					" We've deposited " (msnGetData gSource 'reward) " credits to your account.\""
-					)
+				"Great work! Maybe the warlords will think twice before attacking us again.
+				We've deposited %payment% to your account."
+
+			</Text>
+			<Text id="SuccessDebrief:miscEnemy">
+
+				"Great work! Now we can live in peace.
+				We've deposited %payment% to your account."
+
 			</Text>
 			<Text id="SuccessMsg">
 				Mission complete!

--- a/TransCore/CommonwealthMission01.xml
+++ b/TransCore/CommonwealthMission01.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<TranscendenceModule>
+	
+	<!-- Destroy Threat to Commonwealth Habitat ================================
+	
+	EXTRA DATA
+	
+		reward:				Reward (in credits) for completing mission
+		targetID:			Id of station to destroy
+		targetType:			One of:
+								'centauriWarlords
+								'miscEnemy
+
+	NOTES
+	
+		
+	======================================================================== -->
+	
+	<MissionType UNID="&msDestroyThreatToSlums;"
+			name=				"Destroy Threat to Commonwealth Habitat"
+			attributes=			"commonwealth, commonwealthHabitat"
+
+			level=				"1-4"
+			scope=				"system"
+			>
+
+		<Events>
+			<OnCreate>
+				; Called when mission object is created. This adds the mission
+				; to the list of available missions, but it does not necessarily
+				; start the mission.
+				;
+				; The script may call msnDestroy to abort creation of the mission.
+				;
+				; gSource is mission object
+				; gData is arbitrary data passed in to msnCreate
+				; aOwnerObj is the object that created the mission (or nil)
+
+				(block (enemyStations)
+
+					(switch
+
+						; Get a list of enemy stations in the region. If we cannot find any
+						; suitable targets then we don't have a mission.
+
+						(not (setq enemyStations (sysFindObject aOwnerObj "TAE +populated; -uncharted; N:450;")))
+							(msnDestroy gSource)
+
+						; Otherwise we can create a mission
+
+						(block (targetObj)
+
+							; Pick a random enemy station to destroy
+							(setq targetObj (seededRandom (objGetDestiny aOwnerObj) enemyStations))
+
+							; Remember it
+							(msnSetData gSource 'targetID (objGetID targetObj))
+
+							; Register for events so we know when the target is destroyed
+							(msnRegisterForEvents gSource targetObj)
+
+							; Remember the type of enemy
+							(switch
+								(objHasAttribute targetObj "centauriWarlords")
+									(msnSetData gSource 'targetType 'centauriWarlords)
+
+								(msnSetData gSource 'targetType 'miscEnemy)
+								)
+
+							; Compute reward
+							(msnSetData gSource 'reward (add 200 (multiply (objGetLevel targetObj) 100)))
+							)
+						)
+					)
+			</OnCreate>
+
+			<OnAccepted>
+				; Called if the player accepts the mission. The mission is 
+				; already running (OnStarted has been called).
+				;
+				; gSource is mission object
+
+			</OnAccepted>
+
+			<OnDeclined>
+				; Called if the player rejects the mission. The mission is already
+				; running (OnStarted has been called).
+				;
+				; gSource is mission object.
+
+			</OnDeclined>
+
+			<OnStarted>
+				; Called when the mission starts. This is called if the mission
+				; starts running (either because the player accepted or some other
+				; reason).
+				;
+				; gSource is mission object.
+
+			</OnStarted>
+
+			<OnSetPlayerTarget>
+				; Called to refresh the player's target. Always called right after
+				; the player accepts the mission. May be called at other times
+				; (e.g., after the player returns to the system).
+				;
+				; gSource is mission object
+				; aReason is:
+				;		'accepted: Mission has been accepted
+				;		'debriefed: Player has been debriefed
+				;		'failure: Mission failed
+				;		'inProgress: Player visited station while mission in progress
+				;		'newSystem: Player is in a new system
+				;		'success: Mission completed successfully
+
+				(block (targetObj)
+					(switch
+						; If we just got debriefed then we clear our targets.
+
+						(eq aReason 'debriefed)
+							(shpCancelOrders gPlayerShip)
+
+						; If the mission is complete, then we point towards the
+						; owner station.
+
+						(msnGetProperty gSource 'isCompleted)
+							(if (setq targetObj (objGetObjByID (msnGetProperty gSource 'ownerID)))
+								(block Nil
+									(shpCancelOrders gPlayerShip)
+									(shpOrder gPlayerShip 'dock targetObj)
+									)
+								)
+
+						; Otherwise, we point towards the target
+
+						(if (setq targetObj (objGetObjByID (msnGetData gSource 'targetID)))
+							(block Nil
+								(shpCancelOrders gPlayerShip)
+								(shpOrder gPlayerShip 'attack targetObj)
+								)
+							)
+						)
+					)
+			</OnSetPlayerTarget>
+
+			<OnObjDestroyed>
+				(switch
+					(eq (objGetID aObjDestroyed) (msnGetData gSource 'targetID))
+						(msnSuccess gSource)
+					)
+			</OnObjDestroyed>
+
+			<OnCompleted>
+				; Called when the mission ends (generally because msnSuccess or
+				; msnFailure were called).
+				;
+				; gSource is mission object
+				; gData is arbitrary data passed in to msnSuccess or msnFailure
+				; aReason is:
+				;		'failure: Mission failed
+				;		'success: Mission completed successfully
+
+			</OnCompleted>
+
+			<OnReward>
+				; Called by msnReward, generally during debrief.
+				;
+				; gSource is mission object
+				; gData is data passed to msnReward
+
+				(intMissionRewardPayment (msnGetData gSource 'reward))
+			</OnReward>
+
+			<OnDestroy>
+				; Called when mission object is destroyed (after mission ends)
+				;
+				; gSource is mission object
+				;
+				; NOTE: No need to unregister for events because we automatically
+				; unregister when the mission is complete.
+
+			</OnDestroy>
+		</Events>
+
+		<Language>
+			<Text id="Name">
+				"Destroy Threat to Commonwealth Habitat"
+			</Text>
+			<Text id="Summary">
+				(cat
+					"Your mission is to destroy " (objGetName (objGetObjByID (msnGetData gSource 'targetID)) 0x04) " in the " (sysGetName) " system.\n\n"
+					"System: " (sysGetName) "\n"
+					"Payment: " (msnGetData gSource 'reward) " credits"
+					)
+			</Text>
+			<Text id="Intro">
+
+				The station master stands at his console. Managers and 
+				supervisors swarm around him dealing with various crises. He 
+				turns his attention towards you:
+
+				"We could use your help, %brother%. You've got a ship with a 
+				good punch and we got something that needs punching. We'll pay 
+				you, of course."
+
+			</Text>
+			<Text id="Briefing">
+				(block (
+					(targetObj (objGetObjByID (msnGetData gSource 'targetID)))
+					)
+
+					(switch
+						(eq (msnGetData gSource 'targetType) 'centauriWarlords)
+							(cat
+								"\"A band of Centauri warlords has been harassing this station recently. We've discovered the location of their base and we want you to go there and destroy them. "
+								"If you succeed we'll pay you " (msnGetData gSource 'reward) " credits. Will you help us?\""
+								)
+
+						(cat
+							"\"" (objGetName targetObj 0x05) " nearby has been attacking us recently. We want you to destroy them! "
+							"If you succeed we'll pay you " (msnGetData gSource 'reward) " credits. Will you help us?\""
+							)
+						)
+					)
+			</Text>
+			<Text id="AcceptReply">
+
+				"Thank you! I knew we could count on you. We'll program the 
+				target into your ship's computer. Just follow the arrow on your 
+				screen and you'll get there. Good luck!"
+
+			</Text>
+			<String id="DeclineReply">
+				"Ah, Hell! What are you doing here then? Stop wasting my time!"
+			</String>
+			<Text id="InProgress">
+
+				"What's wrong? You said you could handle this mission! Get back 
+				out there and finish the job!"
+
+			</Text>
+			<Text id="SuccessDebrief">
+				(cat
+					(switch
+						(eq (msnGetData gSource 'targetType) 'centauriWarlords)
+							"\"Great work! Maybe the warlords will think twice before attacking us again."
+
+						"\"Great work! Now we can live in peace. "
+						)
+					" We've deposited " (msnGetData gSource 'reward) " credits to your account.\""
+					)
+			</Text>
+			<Text id="SuccessMsg">
+				Mission complete!
+			</Text>
+			<String id="AlreadyDebriefed">
+				"Welcome back! Thanks for the great work last time."
+			</String>
+			<String id="Unavailable">
+				"Sorry, there are no missions available."
+			</String>
+		</Language>
+	</MissionType>
+
+</TranscendenceModule>

--- a/TransCore/CorporateHierarchy.xml
+++ b/TransCore/CorporateHierarchy.xml
@@ -1895,7 +1895,7 @@
 					attributes: "commonwealthPub"
 					priority: 24
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					data: {station: (objGetName gSource)}
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}
@@ -1987,7 +1987,7 @@
 				You feel out of place here.
 			</Text>
 
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				You talk to a corporate woman staying at the %station%. She drones on
 				about the excellent service. You spend 5 credits on drinks.
 			</Text>

--- a/TransCore/CorporateHierarchy.xml
+++ b/TransCore/CorporateHierarchy.xml
@@ -1894,7 +1894,6 @@
 				{
 					attributes: "commonwealthPub"
 					priority: 24
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					data: {station: (objGetName gSource)}
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))

--- a/TransCore/DeathDrugsCartel.xml
+++ b/TransCore/DeathDrugsCartel.xml
@@ -146,13 +146,13 @@
 					attributes: "commonwealthPub"
 					priority: 40
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>
 		</Events>
 
 		<Language>
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				An old man talks to you:
 
 				"I don't trust the corporate medlabs&mdash;they talk about drug

--- a/TransCore/DeathDrugsCartel.xml
+++ b/TransCore/DeathDrugsCartel.xml
@@ -145,7 +145,6 @@
 				{
 					attributes: "commonwealthPub"
 					priority: 40
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>

--- a/TransCore/HumanSpaceVol01.xml
+++ b/TransCore/HumanSpaceVol01.xml
@@ -1912,6 +1912,7 @@
 	<!ENTITY rsCentauriHeavyRaiderHD	"0x001003F0">
 	<!ENTITY rsCentauriRaiderHD			"0x001003F1">
 	<!ENTITY evCentauriOccupation		"0x001003F2">
+	<!ENTITY evArcoVaughn				"0x001003F3">
 
 	<!-- 0410-042F KOBOL WARLORDS -->
 

--- a/TransCore/HumanSpaceVol01.xml
+++ b/TransCore/HumanSpaceVol01.xml
@@ -2114,6 +2114,7 @@
 	<Module filename="CommonwealthMilitiaMission04.xml"/>
 	<Module filename="CommonwealthMilitiaMissionSK01.xml"/>
 	<Module filename="CommonwealthMining.xml"/>
+	<Module filename="CommonwealthMission01.xml"/>
 	<Module filename="CommonwealthShips.xml"/>
 	<Module filename="CommonwealthStarCarrier.xml"/>
 	<Module filename="CorporateHierarchy.xml"/>

--- a/TransCore/HumanSpaceVol01.xml
+++ b/TransCore/HumanSpaceVol01.xml
@@ -1896,6 +1896,7 @@
 	<!ENTITY rsEI100HD					"0x00100397">
 	<!ENTITY rsEI100Hero				"0x00100398">
 	<!ENTITY rsSapphire					"0x00100399">
+	<!ENTITY msRaisuStation				"0x0010039A">
 
 	<!-- 03B0-03CF SAPIENS -->
 
@@ -1910,6 +1911,7 @@
 
 	<!ENTITY rsCentauriHeavyRaiderHD	"0x001003F0">
 	<!ENTITY rsCentauriRaiderHD			"0x001003F1">
+	<!ENTITY evCentauriOccupation		"0x001003F2">
 
 	<!-- 0410-042F KOBOL WARLORDS -->
 

--- a/TransCore/KorolovShipping.xml
+++ b/TransCore/KorolovShipping.xml
@@ -741,9 +741,9 @@
 						priority: 21
 						sourceObj: gSource
 						textID: (switch
-							(or (not rank) (= rank 0))	'rumor.pub.norank
-							(ls rank 0)					'rumor.pub.blacklisted
-														'rumor.pub.member
+							(or (not rank) (= rank 0))	'rumor.commonwealthPub.norank
+							(ls rank 0)					'rumor.commonwealthPub.blacklisted
+														'rumor.commonwealthPub.member
 							)
 						data: {station: (objGetName gSource)}
 						onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
@@ -844,16 +844,16 @@
 				escort ships. Do not challenge these ships unless you know what you're doing.
 			</Text>
 
-			<Text id="rumor.pub.norank">
+			<Text id="rumor.commonwealthPub.norank">
 				You spend 5 credits on drinks. You talk to a couple of freighter pilots
 				who try to convince you to fly escort missions for Korolov Shipping.
 			</Text>
-			<Text id="rumor.pub.blacklisted">
+			<Text id="rumor.commonwealthPub.blacklisted">
 				A group of freighter pilots point in your direction, talking about how
 				you blew your escort mission. You settle up a 5 credit tab and get ready
 				to leave.
 			</Text>
-			<Text id="rumor.pub.member">
+			<Text id="rumor.commonwealthPub.member">
 				A group of freighter pilots welcome you into their group. You tell various
 				stories about your run-ins with the Charon pirates, but in the end you still
 				get stuck with the 5 credit tab.

--- a/TransCore/KorolovShipping.xml
+++ b/TransCore/KorolovShipping.xml
@@ -739,7 +739,6 @@
 					{
 						attributes: "commonwealthPub"
 						priority: 21
-						sourceObj: gSource
 						textID: (switch
 							(or (not rank) (= rank 0))	'rumor.commonwealthPub.norank
 							(ls rank 0)					'rumor.commonwealthPub.blacklisted

--- a/TransCore/Outlaws.xml
+++ b/TransCore/Outlaws.xml
@@ -482,7 +482,6 @@
 				{
 					attributes: "commonwealthPub"
 					priority: 11
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>

--- a/TransCore/Outlaws.xml
+++ b/TransCore/Outlaws.xml
@@ -483,13 +483,13 @@
 					attributes: "commonwealthPub"
 					priority: 11
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>
 		</Events>
 
 		<Language>
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				You spend 5 credits on drinks. A young stationer next to you
 				comments that its a lot easier to get laudanum now that the
 				Outlaw base is in the system.

--- a/TransCore/Penitents.xml
+++ b/TransCore/Penitents.xml
@@ -92,13 +92,13 @@
 					attributes: "commonwealthPub"
 					priority: 50
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>
 		</Events>
 
 		<Language>
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				You drink through 5 credits while talking to an attractive Sister:
 
 				"The Sisters of Domina believe in the power of transcendence, but

--- a/TransCore/Penitents.xml
+++ b/TransCore/Penitents.xml
@@ -91,7 +91,6 @@
 				{
 					attributes: "commonwealthPub"
 					priority: 50
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>

--- a/TransCore/RPGRumors.xml
+++ b/TransCore/RPGRumors.xml
@@ -41,6 +41,7 @@
 				<OnPaneInit>
 					(block (
 						(sourceObj (@ gData 'sourceObj))
+						(sourceTyp (@ gData 'sourceType))
 						(rumorIntro (objTranslate gSource 'rumor.intro))
 
 						(theRumor (switch
@@ -55,6 +56,7 @@
 									desc: (cat rumorIntro
 										(or
 											(objTranslate sourceObj (@ gData 'textID) (@ gData 'data))
+											(typTranslate sourceTyp (@ gData 'textID) (@ gData 'data))
 											(@ gData 'desc)
 											)
 										)
@@ -103,7 +105,7 @@
 				;		rumor.attrib[.suffix]
 				;
 				;	attrib:	Rumor attribute e.g. commonwealthMining
-				;	suffix:	Added to the end of textID. Make be a sequence [optional]
+				;	suffix:	Added to the end of textID. May be a sequence [optional]
 				;	priority:	Rumor priority [default 10]
 				;	special:	May be one of the following:
 				;		'scan		Scan (i.e. objSetKnow) the source station after displaying rumor
@@ -163,10 +165,25 @@
 						stationObj:gSource
 						})
 
+					;	Lambda to add sourceType to global rumors
+					(wrapGlobalRumor (lambda (rumors theType)
+						(switch
+							(= (typeOf rumors) 'struct)
+								(set@ rumors { sourceObj:Nil sourceType:theType })
+							(= (typeOf rumors) 'list)
+								(map rumors theRumor
+									(set@ theRumor { sourceObj:Nil sourceType:theType })
+									)
+							)
+						))
+
 					;	Build rumor list from: global types, local stations, and missions
 					(allRumors (apply append (append
 						(map (typFind "*") 'excludeNil theType
-							(typFireEvent theType 'GetGlobalRumors eventData)
+							(wrapGlobalRumor
+								(typFireEvent theType 'GetGlobalRumors eventData)
+								theType
+								)
 							)
 						(map (sysFindObject Nil "AT") 'excludeNil theObj
 							(objFireEvent theObj 'GetRumors eventData)

--- a/TransCore/RPGRumors.xml
+++ b/TransCore/RPGRumors.xml
@@ -126,7 +126,6 @@
 					{
 						attributes: attrib
 						priority: (or priority 10)
-						sourceObj: gSource
 						textID: (cat "rumor." attrib (if suf ".") suf)
 						data: data
 						onExitRumor: (switch
@@ -175,14 +174,14 @@
 						stationObj:gSource
 						})
 
-					;	Lambda to add sourceType to global rumors
-					(wrapGlobalRumor (lambda (rumors theType)
+					;	Lambda to set rumor defaults
+					(setRumorDefaults (lambda (default rumors)
 						(switch
 							(= (typeOf rumors) 'struct)
-								(set@ rumors { sourceObj:Nil sourceType:theType })
+								(struct default rumors)
 							(= (typeOf rumors) 'list)
 								(map rumors theRumor
-									(set@ theRumor { sourceObj:Nil sourceType:theType })
+									(struct default theRumor)
 									)
 							)
 						))
@@ -190,16 +189,22 @@
 					;	Build rumor list from: global types, local stations, and missions
 					(allRumors (apply append (append
 						(map (typFind "*") 'excludeNil theType
-							(wrapGlobalRumor
+							(setRumorDefaults
+								{	sourceType: theType	}
 								(typFireEvent theType 'GetGlobalRumors eventData)
-								theType
 								)
 							)
 						(map (sysFindObject Nil "AT") 'excludeNil theObj
-							(objFireEvent theObj 'GetRumors eventData)
+							(setRumorDefaults
+								{	sourceObj: theObj	}
+								(objFireEvent theObj 'GetRumors eventData)
+								)
 							)
 						(map (msnFind "*") 'excludeNil msnObj
-							(msnFireEvent msnObj 'GetRumors eventData)
+							(setRumorDefaults
+								{	sourceObj: msnObj	}
+								(msnFireEvent msnObj 'GetRumors eventData)
+								)
 							)
 						)))
 

--- a/TransCore/RPGRumors.xml
+++ b/TransCore/RPGRumors.xml
@@ -43,6 +43,7 @@
 						(sourceObj (@ gData 'sourceObj))
 						(sourceTyp (@ gData 'sourceType))
 						(rumorIntro (objTranslate gSource 'rumor.intro))
+						(descID (or (@ gData 'descID) (@ gData 'textID)))
 
 						(theRumor (switch
 							;	If we have a dialogID then translate from sourceObj
@@ -55,10 +56,19 @@
 								{
 									desc: (cat rumorIntro
 										(or
-											(objTranslate sourceObj (@ gData 'textID) (@ gData 'data))
-											(typTranslate sourceTyp (@ gData 'textID) (@ gData 'data))
+											(objTranslate sourceObj descID (@ gData 'data))
+											(typTranslate sourceTyp descID (@ gData 'data))
 											(@ gData 'desc)
 											)
+										)
+									}
+
+							;	If we have a global rumor then we need to translate descID
+							sourceTyp
+								{
+									desc: (or
+										(typTranslate sourceTyp descID (@ gData 'data))
+										(@ gData 'desc)
 										)
 									}
 

--- a/TransCore/RPGRumors.xml
+++ b/TransCore/RPGRumors.xml
@@ -79,7 +79,7 @@
 
 						(rpgPagePaneInit gScreen theRumor
 							{
-								actionDoneID: 'actionLeave
+								actionDoneID: (or (@ gData 'actionDoneID) 'actionContinue)
 								;	sourceObj may be either mission or space object, but
 								;	objTranslate and msnTranslate are identical so this works
 								missionObj: sourceObj
@@ -157,6 +157,9 @@
 				;
 				;		rumorCriteria: Criteria used to find suitable rumors. If not
 				;				supplied then fallback to mission/display criteria
+				;
+				;		actionDoneID: Action ID to use for the done button (defaults to
+				;				'actionContinue).
 
 				(block (
 					;	
@@ -226,7 +229,39 @@
 						(ls (setq theRoll (- theRoll (@ theRumor 'priority))) 1)
 						))
 					)
+
+					(if (@ options 'actionDoneID)
+						(set@ theRumor 'actionDoneID (@ options 'actionDoneID))
+						)
 					theRumor
+					)
+				))
+
+			(setq rpgRumorShow (lambda (options)
+
+				;	Options may contain the following fields
+				;
+				;		rumorCriteria: Criteria used to find suitable rumors. If not
+				;				supplied then fallback to mission/display criteria
+				;
+				;		noRumorTextID: Language ID to display if there are no rumors
+				;				available at this station. [Required]
+				;
+				;		actionDoneID: Action ID to use for the done button (defaults to
+				;				'actionContinue).
+
+				(block (
+					(noRumorTextID (@ options 'noRumorTextID))
+					theRumor
+					)
+					(switch
+						;	Check if we have any rumors
+						(setq theRumor (rpgGetRumor options))
+							(scrShowScreen gScreen &dsRPGRumor; theRumor)
+
+						; Otherwise, nothing
+						(scrShowScreen gScreen &dsRPGMessage; { desc:(scrTranslate gScreen noRumorTextID) })
+						)
 					)
 				))
 			)

--- a/TransCore/RaisuStation.xml
+++ b/TransCore/RaisuStation.xml
@@ -112,19 +112,17 @@
 			<OnCreate>
 				(block (
 					(arcoVaughn (sysFindObject gSource "sN +arcoVaughn;"))
+					(baseObj (sysFindObject gSource "TN +arcoVaughn;"))
 					)
 					(switch
 						(not arcoVaughn)
 							(msnDestroy gSource)
 
 						(block Nil
+							;	Raisu does not allow docking once mission is in progress
 							(msnSetData gSource 'destID (objGetID aOwnerObj))
 
-							;	Remove Commonwealth ships
-							(objSetProperty aOwnerObj 'shipReinforcementEnabled Nil)
-							(enum (sysFindObject aOwnerObj "sO:docked;") theShip (objDestroy theShip))
-
-							;	Disable Commonwealth customs
+							;	Start occupation
 							(objSetEventHandler aOwnerObj &evCentauriOccupation;)
 
 							;	Add Centauri Raiders
@@ -135,6 +133,15 @@
 									)
 								)
 
+							;	Warlord base
+							(objAddItem baseObj (itmSetData
+								(itmCreate &itDataROM; 1)
+								'Text
+								(msnTranslate gSource 'descArcoMessage)
+								))
+
+							;	Setup Arco Vaughn
+							(objSetEventHandler arcoVaughn &evArcoVaughn;)
 							(msnSetData gSource 'targetID (objGetID arcoVaughn))
 							(msnRegisterForEvents gSource arcoVaughn)
 
@@ -194,6 +201,7 @@
 			<OnTimer>
 				(block (
 					(stationObj (objGetObjByID (msnGetProperty gSource 'ownerID)))
+					(arcoVaughn (objGetObjByID (msnGetData gSource 'targetID)))
 					)
 					(switch
 						;	If not in Starton Eridani, then nothing to do
@@ -206,12 +214,7 @@
 
 						;	If we've already summoned lots of raiders, then send Arco Vaughn
 						(gr (msnGetData gSource 'raidersSummoned) 20)
-							(block (arcoVaughn)
-								(setq arcoVaughn (sysFindObject stationObj "sN +arcoVaughn;"))
-								(if arcoVaughn
-									(objFireEvent arcoVaughn "OrderKillPlayer")
-									)
-								)
+							(objFireEvent arcoVaughn "OrderKillPlayer")
 
 						;	Otherwise summon some more raiders
 						(leq (random 1 100) 20)
@@ -233,10 +236,12 @@
 			</OnTimer>
 
 			<OnObjDestroyed>
+				;	If the mission is still open we need to make it a non-player mission
+				;	so the OnCompleted event is called. Note - msnSetUnavailable does not
+				;	affect player missions, so it is safe to call without any checking.
 				(switch
 					(= (objGetID aObjDestroyed) (msnGetProperty gSource 'ownerID))
 						(block Nil
-							;	If the mission is still open we need to make it a non-player mission
 							(msnSetUnavailable gSource)
 							(msnFailure gSource {
 								destroyedByPlayer: (and gPlayerShip (= aOrderGiver gPlayerShip))
@@ -245,7 +250,9 @@
 
 					(= (objGetID aObjDestroyed) (msnGetData gSource 'targetID))
 						(block Nil
-							;	If the mission is still open we need to make it a non-player mission
+							;	Backward compatibility for old Container Habitat rumors
+							(typSetData &scArcoVaughnHeavyRaider; 'status 'destroyed)
+
 							(msnSetUnavailable gSource)
 							(msnSuccess gSource)
 							)
@@ -536,6 +543,25 @@
 
 			</Text>
 
+			<Text id="descArcoMessage">
+				RECEIVED from relay07.cynus.anderson.187janus_station.comm\n
+				by helios_receiver.f5astarton_eridani.comm (EID 089830_7188919)\n
+				for &lt;arcovaughn.17591&gt; (EID 089830_8179210) 2403-11-25 17:34:11
+
+				MESSAGE BEGINS\n
+				I know that you must hate me right now; truth is I don't like myself very
+				much either. But I promise you that everything happens for a reason and that
+				one day you and I will both understand. I can't explain to you or anyone why
+				I'm going. No one can understand. But I know that I am doing the right thing
+				and I know that I am doing what I must. I can't do anything else. Something
+				is about to happen. Something feels wrong. Whatever fate awaits me at the
+				Core, I know that it is entwined with the fate of all Humanity. When I get
+				there, I will understand. When I get there, we will all understand. I must
+				get there before it is too late. Take care of your mother.
+
+				MESSAGE ENDS
+			</Text>
+
 			<Text id="rumor.commonwealthHabitat.1">
 				"The warlords are annoying, but they don't mean much. The only one that bothers
 				me is Arco Vaughn. He's trouble. Someone ought to air him out before things get
@@ -581,8 +607,230 @@
 
 <!-- BEHAVIORS -->
 
+	<!-- Arco Vaughn
+
+	GLOBAL DATA
+
+	status:				Status of Arco Vaughn
+							Nil						= never encountered
+							"destroyed"				= destroyed
+
+	EXTRA DATA
+
+	home:				Our container
+
+	behavior:			Current behavior
+							Nil						= waiting for player
+							'scarePlayer			= scare the player, shoot if shields are full
+							'scarePlayerWithForce	= shoot at player but stop when shields drop
+							'killPlayer				= kill the player
+
+	warning:			True if we warned the player
+
+	-->
+
+	<Type UNID="&evArcoVaughn;">
+		<Events>
+			<OnEventHandlerInit>
+				(block Nil
+					;	Set a timer so that we can do some custom behavior
+					(sysAddObjRecurringTimerEvent 10 gSource "OnBehavior")
+
+					;	Remember our home
+					(objSetObjRefData gSource "home" (sysFindObject gSource "TN +arcoVaughn;"))
+					)
+			</OnEventHandlerInit>
+
+			<OnAttacked>
+				(if (and (eq aOrderGiver gPlayerShip)
+						(not (eq (objGetData gSource "behavior") 'killPlayer)))
+					(if (and (or (eq aDamageType 'kinetic) (eq aDamageType 'laser))
+							(leq aDamageHP 6)
+							)
+
+						;	If we're attacked with laser or kinetic, laugh it off
+
+						(if (and (eq (random 1 3) 1)
+								(eq (objGetData gSource "behavior") 'scarePlayer))
+							(objSendMessageTranslate gPlayerShip gSource 'msgTickled)
+							)
+
+						;	If we're attacked with something more powerful, then we
+						;	attack in force.
+
+						(block Nil
+							(shpCancelOrders gSource)
+							(shpOrder gSource 'attack gPlayerShip)
+							(objSetData gSource "behavior" 'killPlayer)
+
+							(objSendMessageTranslate gPlayerShip gSource 'msgWTF)
+							)
+						)
+					)
+			</OnAttacked>
+
+			<OnBehavior>
+				(block (
+					(behavior (objGetData gSource 'behavior))
+					(homeObj (objGetObjRefData gSource 'home))
+					)
+
+					(switch
+						;	Wait for player to show up
+						(not behavior)
+							(if (and gPlayerShip
+									(ls (objGetDistance gPlayerShip gSource) 60)
+									(ls (objGetDistance gPlayerShip homeObj) 200))
+								(block Nil
+
+									; Once the player shows up, aim for the player, but don't attack yet
+									(shpCancelOrders gSource)
+									(shpOrder gSource 'aim gPlayerShip)
+
+									(objRegisterForEvents gSource gPlayerShip)
+									(objSetData gSource "behavior" 'scarePlayer)
+									)
+								)
+
+						;	Scare the player away
+						(eq behavior 'scarePlayer)
+							(block Nil
+								(if (eq (objGetShieldLevel gPlayerShip) 100)
+									(block Nil
+										(shpCancelOrders gSource)
+										(shpOrder gSource 'attack gPlayerShip)
+										(objSetData gSource "behavior" 'scarePlayerWithForce)
+										)
+									)
+
+								(if (gr (objGetDistance gPlayerShip homeObj) 300)
+									(block Nil
+										(shpCancelOrders gSource)
+										(shpOrder gSource 'patrol homeObj 5)
+										(objSetData gSource "behavior" Nil)
+										(objSetData gSource "warning" Nil)
+										)
+									)
+								)
+
+						(eq behavior 'scarePlayerWithForce)
+							(block Nil
+								(if (ls (objGetShieldLevel gPlayerShip) 100)
+									(block Nil
+										(shpCancelOrders gSource)
+										(shpOrder gSource 'aim gPlayerShip)
+										(objSetData gSource "behavior" 'scarePlayer)
+										)
+									)
+
+								(if (and
+										(not (objGetData gSource "warning"))
+										(ls (objGetDistance gSource gPlayerShip) 25)
+										)
+									(block Nil
+										(objSendMessageTranslate gPlayerShip gSource 'msgGoHome)
+										(objSetData gSource "warning" True)
+										)
+									)
+
+								(if (gr (objGetDistance gPlayerShip homeObj) 300)
+									(block Nil
+										(shpCancelOrders gSource)
+										(shpOrder gSource 'patrol homeObj 5)
+										(objSetData gSource "behavior" Nil)
+										(objSetData gSource "warning" Nil)
+										)
+									)
+								)
+						)
+					)
+			</OnBehavior>
+
+			<OnDamage>
+				(block Nil
+
+					;	If the player damaged us, then attack
+					(if (and (eq aAttacker gPlayerShip)
+							(not (eq (objGetData gSource "behavior") 'killPlayer)))
+						(block Nil
+							(shpCancelOrders gSource)
+							(shpOrder gSource 'attack gPlayerShip)
+							(objSetData gSource "behavior" 'killPlayer)
+
+							(objSendMessageTranslate gPlayerShip gSource 'msgWTF)
+							)
+						)
+
+					;	We always return full hit points
+					aDamageHP
+					)
+			</OnDamage>
+
+			<OnObjDestroyed>
+				(if (eq aObjDestroyed gPlayerShip)
+					(block Nil
+						(shpCancelOrders gSource)
+						(shpOrder gSource 'patrol (objGetObjRefData gSource "home") 5)
+						(objSetData gSource "behavior" Nil)
+						)
+					)
+			</OnObjDestroyed>
+
+			<OrderKillPlayer>
+				(block Nil
+					(shpCancelOrders gSource)
+					(shpOrder gSource 'attack gPlayerShip)
+					(objSetData gSource "behavior" 'killPlayer)
+					)
+			</OrderKillPlayer>
+		</Events>
+
+		<Language>
+			<!-- Code Points -->
+
+			<Text id="msgGoHome">(objTranslate gSource (cat 'msgGoHome (random 1 6)))</Text>
+			<Text id="msgTickled">(objTranslate gSource (cat 'msgTickled (random 1 6)))</Text>
+			<Text id="msgWTF">(objTranslate gSource (cat 'msgWTF (random 1 6)))</Text>
+
+			<!-- Text -->
+
+			<Text id="msgGoHome1">Go home before you hurt yourself, kid</Text>
+			<Text id="msgGoHome2">This isn't your fight; get out while you can</Text>
+			<Text id="msgGoHome3">That was a warning</Text>
+			<Text id="msgGoHome4">This is a restricted area; I will shoot</Text>
+			<Text id="msgGoHome5">Go home; this system is mine!</Text>
+			<Text id="msgGoHome6">Don't make me destroy you</Text>
+
+			<Text id="msgTickled1">Quit it!</Text>
+			<Text id="msgTickled2">Go home kid, or I'm really going to get mad</Text>
+			<Text id="msgTickled3">What, did I kill your microsaur or something?</Text>
+			<Text id="msgTickled4">Forget it, you don't have a chance!</Text>
+			<Text id="msgTickled5">Clear out or I will blast you!</Text>
+			<Text id="msgTickled6">Don't make me bust you up</Text>
+
+			<Text id="msgWTF1">What the...!?</Text>
+			<Text id="msgWTF2">You are going to die!</Text>
+			<Text id="msgWTF3">You are dead!</Text>
+			<Text id="msgWTF4">Enough!</Text>
+			<Text id="msgWTF5">Kack!</Text>
+			<Text id="msgWTF6">Huh!?</Text>
+		</Language>
+	</Type>
+
+	<!-- Centauri Occupation -->
+
 	<Type UNID="&evCentauriOccupation;">
 		<Events>
+			<OnEventHandlerInit>
+				(block Nil
+					(objSetProperty gSource 'shipReinforcementEnabled Nil)
+					(objSetProperty gSource 'shipConstructionEnabled Nil)
+
+					;	Remove Commonwealth ships
+					(enum (sysFindObject gSource "sO:docked;") theShip (objDestroy theShip))
+					)
+			</OnEventHandlerInit>
+
 			<GetCommonwealthCustomsStatus>
 				'disabled
 			</GetCommonwealthCustomsStatus>

--- a/TransCore/RaisuStation.xml
+++ b/TransCore/RaisuStation.xml
@@ -367,7 +367,6 @@
 							{
 								attributes: 'commonwealthHabitat
 								priority: 10000
-								sourceObj: gSource
 								dialogID: 'descMeetingHallHappy
 								}
 							)

--- a/TransCore/RaisuStation.xml
+++ b/TransCore/RaisuStation.xml
@@ -377,7 +377,10 @@
 					(msnGetProperty gSource 'isFailure)
 						Nil
 
-					(rpgRumorAdd 'commonwealthHabitat (make 'sequence 1 4) 20)
+					(append
+						(rpgRumorAdd 'commonwealthHabitat (make 'sequence 1 4) 20)
+						(rpgRumorAdd 'commonwealthContainer (make 'sequence 1 5) 20)
+						)
 					)
 			</GetRumors>
 		</Events>
@@ -595,6 +598,27 @@
 			<Text id="rumor.commonwealthHabitat.8">
 				"We're all glad that Arco Vaughn is dead. I heard someone from Raisu station
 				finally had enough and decided to chase him down."
+			</Text>
+			<Text id="rumor.commonwealthContainer.1">
+				"Watch out for Arco Vaughn. He is the most dangerous Centauri warlord;
+				his heavy raider is protected against lasers and recoilless cannons.
+				Avoid him if you want to live."
+			</Text>
+			<Text id="rumor.commonwealthContainer.2">
+				"Arco Vaughn flies an enhanced heavy raider. His armor is protected against
+				normal weapons; you'll need missiles to kill him."
+			</Text>
+			<Text id="rumor.commonwealthContainer.3">
+				"Raisu Station is in trouble. The Centauri warlords have taken it over;
+				don't go there unless you are armed and ready."
+			</Text>
+			<Text id="rumor.commonwealthContainer.4">
+				"If you want to find Arco Vaughn, go to Raisu Station. Talk to the station
+				master there. She will help you."
+			</Text>
+			<Text id="rumor.commonwealthContainer.5">
+				"The Centauri warlords have many bases among the outer asteroids of Eridani;
+				but if you go there, watch out: Arco Vaughn is there too."
 			</Text>
 
 			<Text id="achievement.liberated">Liberated Raisu station</Text>

--- a/TransCore/RaisuStation.xml
+++ b/TransCore/RaisuStation.xml
@@ -357,7 +357,14 @@
 						Nil
 
 					(= (msnGetProperty gSource 'ownerID) (objGetID (@ gData 'stationObj)))
-						Nil
+						(if (msnGetProperty gSource 'isSuccess)
+							{
+								attributes: 'commonwealthHabitat
+								priority: 10000
+								sourceObj: gSource
+								dialogID: 'descMeetingHallHappy
+								}
+							)
 
 					(msnGetProperty gSource 'isSuccess)
 						(rpgRumorAdd 'commonwealthHabitat (make 'sequence 5 8) 20)

--- a/TransCore/RaisuStation.xml
+++ b/TransCore/RaisuStation.xml
@@ -2,32 +2,13 @@
 
 <TranscendenceModule>
 
-	<!-- Raisu Station
-	
-	GLOBAL DATA
-	
-	status:				Status of Raisu station
-							Nil						= Controlled by Centauri Warlords
-							'destroyed				= Destroyed
-							'destroyedByPlayer		= Destroyed by player
-							'liberated				= Liberared
-
-	EXTRA DATA
-	
-	missionStatus:		Status of mission to kill Arco Vaughn
-							Nil						= no mission assigned
-							'inprogress				= Player has agreed to kill Arco Vaughn
-							'declined				= Player has declined mission
-							'success				= Player has killed Arco Vaughn
-							'complete				= Arco Vaughn is dead and player has been rewarded
-
-	raidersSummoned:	Total count of raiders summoned
-
-	-->
+	<!-- Raisu Station -->
 
 	<StationType UNID="&stRaisuStation;"
 			name=				": Raisu Station"
 			sovereign=			"&svCommonwealth;"
+			inherit=			"&baCommonwealthStation;"
+
 			dockScreen=			"Main"
 			abandonedScreen=	"&dsAbandonedStation;"
 			canAttack=			"true"
@@ -49,211 +30,23 @@
 			<Image	imageID="&rsCommonwealthSlumsImage;" imageX="192" imageY="0" imageWidth="64" imageHeight="128"/>
 		</ImageVariants>
 
-		<Ships>
-			<Ship count="1d4+1"	class="&scCentauriRaider;"	orders="patrol"	patrolDist="10"	sovereign="&svCentauriWarlords;"/>
+		<!-- Ships and Defenses -->
+
+		<Ships challenge="standard">
+			<Lookup table="&tbCommPrivateCrafts;"/>
 		</Ships>
-
-		<Events>
-			<GetGlobalAchievements>
-				(block (theList theStatus)
-					(setq theStatus (typGetGlobalData &stRaisuStation; "status"))
-					
-					(if theStatus
-						(setq theList (list
-							(list 
-								(or (typTranslate &stRaisuStation; (cat "achievement." theStatus))
-									(cat "ERROR: Raisu station status: " theStatus)
-									)
-								Nil 
-								"achievements &amp; regrets"
-								)
-							))
-						)
-						
-					theList
-					)
-			</GetGlobalAchievements>
-
-			<OnCreate>
-				(sysAddObjRecurringTimerEvent 451 gSource "OnTimer")
-			</OnCreate>
-
-			<OnDestroy>
-				(block Nil
-					(if (and gPlayerShip (eq aOrderGiver gPlayerShip))
-						(objSetGlobalData gSource "status" 'destroyedByPlayer)
-						(objSetGlobalData gSource "status" 'destroyed)
-						)
-						
-					(intCommonwealthOnDestroy)
-					)
-			</OnDestroy>
-
-			<OnObjDestroyed>
-				(if (and (eq (objGetData gSource "missionStatus") 'inprogress)
-						(eq aObjDestroyed (objGetObjRefData gSource "target")))
-					(block Nil
-						(objSetData gSource "missionStatus" 'success)
-						(shpCancelOrders gPlayerShip)
-						(shpOrder gPlayerShip 'dock gSource)
-						(plyMessage gPlayer "Mission complete!")
-						)
-					)
-			</OnObjDestroyed>
-
-			<GetCommonwealthCustomsStatus>
-				(switch
-
-					;	No customs if the station is not liberated
-
-					(!= (objGetGlobalData gSource 'status) 'liberated)
-						'disabled
-
-					;	Otherwise, Nil means normal customs
-
-					Nil
-					)
-			</GetCommonwealthCustomsStatus>
-
-			<OnTimer>
-				(block (arcoVaughnStatus)
-					(setq arcoVaughnStatus (typGetGlobalData &scArcoVaughnHeavyRaider; "status"))
-					(switch
-						; If Arco vaughn is destroyed, then some commonwealth ships show up
-						(and (eq arcoVaughnStatus 'destroyed)
-								(ls (count (staGetSubordinates gSource)) 3))
-							(block (theShip)
-								(setq theShip 
-									(sysCreateShip (random '(&scEI100; &scEI100; &scSapphireYacht; &scBorer;))
-										(sysFindObject gSource "GN -uncharted;")
-										&svCommonwealth;
-										)
-									)
-								(shpOrder theShip 'dock gSource)
-								(shpOrder theShip 'gateOnThreat)
-								(objAddSubordinate gSource theShip)
-								)
-
-						; If there are no raiders around, then summon some more
-						(and (not (eq arcoVaughnStatus 'destroyed))
-								(not (objGetData gSource "missionStatus"))
-								(leq (random 1 100) 20)
-								(not (sysFindObject gSource "s +centauriWarlords; N:150")))
-
-							(if (gr (objGetData gSource "raidersSummoned") 20)
-
-								; If we've already summoned lots of raiders, then send Arco Vaughn
-								(block (arcoVaughn)
-									(setq arcoVaughn (sysFindObject gSource "sN +arcoVaughn;"))
-									(if arcoVaughn
-										(objFireEvent arcoVaughn "OrderKillPlayer")
-										)
-									)
-
-								; Otherwise, summon more raiders
-								(block (newShips)
-									(setq newShips (random 3 4))
-									(objIncData gSource "raidersSummoned" newShips)
-									(for i 1 newShips
-										(block (theShip)
-											(setq theShip 
-												(sysCreateShip &scCentauriRaider;
-													(sysFindObject gSource "GN -uncharted;")
-													&svCentauriWarlords;
-													)
-												)
-											(shpOrder theShip 'patrol gSource 10)
-											)
-										)
-									)
-								)
-						)
-					)
-			</OnTimer>
-		</Events>
 
 		<DockScreens>
 			<Main>
-				<InitialPane>
-					(block (missionStatus)
-						(setq missionStatus (objGetData gSource "missionStatus"))
-
-						(switch
-							; Mission in progress
-							(eq missionStatus 'inprogress)
-								"MissionInProgress"
-
-							; See if player has destroyed target
-							(eq missionStatus 'success)
-								"MissionSuccess"
-
-							"Default"
-							)
-						)
-				</InitialPane>
-
 				<Panes>
-					<Default>
-						<OnPaneInit>
-							(block (
-								(missionStatus (objGetData gSource 'missionStatus))
-								)
-								(switch
-									;	If we're in the middle of a mission, everyone is hiding
-
-									(or (= missionStatus 'inProgress) (= missionStatus 'declined))
-										(scrSetDescTranslate gScreen 'descHiding)
-
-									;	If there are Centauri raiders in range, then everyone is hiding
-
-									(sysFindObject gSource "s +centauriWarlords; N:100;")
-										(scrSetDescTranslate gScreen 'descHiding)
-
-									;	Otherwise, normal
-
-									(scrSetDescTranslate gScreen 'descNormal)
-									)
-								)
-						</OnPaneInit>
-
+					<Default descID="descNormal">
 						<Actions>
-							<Action id="actionMeetingHall" default="1">
-								(block (missionStatus)
-									; Get some status
-									(setq missionStatus (objGetData gSource "missionStatus"))
-
-									(switch
-										; If Arco Vaughn is dead, everyone is happy
-										(eq (typGetGlobalData &scArcoVaughnHeavyRaider; "status") 'destroyed)
-											(scrShowPane gScreen "MeetingHallHappy")
-
-										; If the player declined, then everyone is still in fear
-										(eq missionStatus 'declined)
-											(scrShowPane gScreen "MeetingHallHiding")
-
-										; If there are Centauri raiders in range, then everyone is hinding
-										(sysFindObject gSource "s +centauriWarlords; N:100;")
-											(scrShowPane gScreen "MeetingHallHiding")
-
-										; Otherwise, see if we get a mission
-										(block (centauriStations centauriStationsDestroyed theStation)
-
-											; Count the number of Centauri stations in the system
-											(setq centauriStations (sysFindObject gSource "T +centauriWarlords; +populated; -occupation; -uncharted;"))
-											(setq centauriStationsDestroyed (filter centauriStations theStation (objIsAbandoned theStation)))
-
-											; If more than 2 stations have been destroyed or if all stations
-											; have been destroyed, then the player gets the Arco Vaughn mission
-											(if (or (geq (count centauriStationsDestroyed) 3) 
-													(eq (count centauriStations) (count centauriStationsDestroyed))
-													(gr (objGetData gSource "raidersSummoned") 12)
-													)
-												(scrShowPane gScreen "MissionIntro")
-												(scrShowPane gScreen "MeetingHallFearful")
-												)
-											)
-										)
-									)
+							<Action id="actionMainHall" default="1">
+								(rpgMissionAssignment {
+									missionCriteria: "n +commonwealthHabitat;"
+									noMissionTextID: 'descNoMissions
+									maxPerStation: 1
+									})
 							</Action>
 
 							<Action id="actionUndock" cancel="1">
@@ -261,183 +54,6 @@
 							</Action>
 						</Actions>
 					</Default>
-
-					<MissionIntro descID="descMissionIntro">
-						<Actions>
-							<Action id="actionContinue" default="1" cancel="1">
-								(scrShowPane gScreen "Mission")
-							</Action>
-						</Actions>
-					</MissionIntro>
-
-					<Mission descID="descMissionBriefing">
-						<Actions>
-							<Action id="actionAccept" default="1">
-								(block (arcoVaughn target launcherItem missileTypes bestType)
-									; Track Arco Vaughn
-									(setq arcoVaughn (sysFindObject gSource "sN +arcoVaughn;"))
-									(objSetObjRefData gSource "target" arcoVaughn)
-									(objRegisterForEvents gSource arcoVaughn)
-
-									; Set the player to Arco Vaughn's habitat
-									(setq target (sysFindObject gSource "TN +arcoVaughn;"))
-									(if (or (not target)
-											(eq (objGetEquipmentStatus gPlayerShip 'TargetingComputer) 'ready))
-										(setq target arcoVaughn)
-										)
-									(shpCancelOrders gPlayerShip)
-									(shpOrder gPlayerShip 'attack target)
-
-									; Give the player some appropriate missiles
-									(switch
-										;	If we don't have a launcher, give a missile rack
-										(not (setq launcherItem (@ (objGetItems gPlayerShip "lI -Disposable;") 0)))
-											(setq gItem (itmCreate &itDM1500MissileRack; 1))
-											
-										;	Find all compatible missiles for this launcher
-										(not (setq missileTypes (itmGetTypes (cat "M +launchedBy:" (itmGetType launcherItem) ";"))))
-											(setq gItem (itmCreate &itDM1500MissileRack; 1))
-										
-										;	Find a tracking missile of level 3 or less.
-										(setq bestType
-												(map missileTypes (list 'reduceMax 'original 'excludeNil) theType 
-													(if (and (itmGetProperty theType 'tracking)
-															(leq (itmGetLevel theType) 3)
-															)
-														(itmGetLevel theType)
-														)
-													)
-												)
-											(setq gItem (itmCreate bestType (random 32 48)))
-											
-										;	Otherwise, any missile of level 5 or less.
-										(setq bestType
-												(map missileTypes (list 'reduceMax 'original 'excludeNil) theType 
-													(if (leq (itmGetLevel theType) 5)
-														(itmGetLevel theType)
-														)
-													)
-												)
-											(setq gItem (itmCreate bestType (random 32 48)))
-											
-										;	Otherwise, default to a missile rack
-										(setq gItem (itmCreate &itDM1500MissileRack; 1))
-										)
-									(objAddItem gPlayerShip gItem)
-
-									; Set mission
-									(objSetData gSource "missionStatus" 'inprogress)
-									(scrShowPane gScreen "MissionAccept")
-									)
-							</Action>
-
-							<Action id="actionDecline" cancel="1">
-								(block Nil
-									(objSetData gSource "missionStatus" 'declined)
-									(scrShowPane gScreen "MissionDecline")
-									)
-							</Action>
-						</Actions>
-					</Mission>
-
-					<MissionAccept>
-						<OnPaneInit>
-							(if (gr (itmGetCount gItem) 1)
-								(scrSetDescTranslate gScreen 'descMissionAcceptPlural { itemName:(itmGetName gItem 0x02) })
-								(scrSetDescTranslate gScreen 'descMissionAcceptSingular { itemName:(itmGetName gItem 0x00) })
-								)
-						</OnPaneInit>
-
-						<Actions>
-							<Action id="actionContinue" default="1" cancel="1">
-								<Exit/>
-							</Action>
-						</Actions>
-					</MissionAccept>
-
-					<MissionDecline descID="descMissionDecline">
-						<Actions>
-							<Action id="actionContinue" default="1" cancel="1">
-								(scrShowPane gScreen "Default")
-							</Action>
-						</Actions>
-					</MissionDecline>
-
-					<MissionSuccess>
-						<OnPaneInit>
-							(if (= (plyGetGenome gPlayer) 'humanMale)
-								(scrSetDescTranslate gScreen 'descMissionSuccessWhisper)
-								(scrSetDescTranslate gScreen 'descMissionSuccessHug)
-								)
-						</OnPaneInit>
-
-						<Actions>
-							<Action id="actionContinue" default="1" cancel="1">
-								(block Nil
-									(shpCancelOrders gPlayerShip)
-									(objSetData gSource "missionStatus" 'complete)
-									(objSetGlobalData gSource "status" 'liberated)
-									(scrShowPane gScreen "Default")
-									)
-							</Action>
-						</Actions>
-					</MissionSuccess>
-
-					<MissionInProgress descID="descMissionHiding">
-						<Actions>
-							<Action id="actionContinue" default="1" cancel="1">
-								(block Nil
-									(shpCancelOrders gPlayerShip)
-									(shpOrder gPlayerShip 'attack (sysFindObject gSource "TN +arcoVaughn;"))
-									(scrExitDock gScreen)
-									)
-							</Action>
-						</Actions>
-					</MissionInProgress>
-
-					<MeetingHallHiding descID="descMissionHiding">
-						<Actions>
-							<Action id="actionContinue" default="1" cancel="1">
-								(scrShowPane gScreen "Default")
-							</Action>
-						</Actions>
-					</MeetingHallHiding>
-
-					<MeetingHallFearful>
-						<OnPaneInit>
-							(block (centauriStations centauriStationsDestroyed)
-
-								;	Count the number of destroyed Centauri stations
-
-								(setq centauriStations (sysFindObject gSource "T +centauriWarlords; +populated; -occupation; -uncharted;"))
-								(setq centauriStationsDestroyed (filter centauriStations theStation (objIsAbandoned theStation)))
-
-								(switch
-									(eq (count centauriStationsDestroyed) 0)
-										(scrSetDescTranslate gScreen 'descStationFearful0)
-
-									(eq (count centauriStationsDestroyed) 1)
-										(scrSetDescTranslate gScreen 'descStationFearful1)
-
-									(scrSetDescTranslate gScreen 'descStationFearful2)
-									)
-								)
-						</OnPaneInit>
-
-						<Actions>
-							<Action id="actionLeave" default="1" cancel="1">
-								(scrShowPane gScreen "Default")
-							</Action>
-						</Actions>
-					</MeetingHallFearful>
-
-					<MeetingHallHappy descID="descMeetingHallHappy">
-						<Actions>
-							<Action id="actionLeave" default="1" cancel="1">
-								(scrShowPane gScreen "Default")
-							</Action>
-						</Actions>
-					</MeetingHallHappy>
 				</Panes>
 			</Main>
 		</DockScreens>
@@ -453,20 +69,332 @@
 		</DockingPorts>
 
 		<Language>
-			<Text id="actionAccept">[A]ccept</Text>
-			<Text id="actionContinue">[C]ontinue</Text>
-			<Text id="actionDecline">[D]ecline</Text>
-			<Text id="actionLeave">[L]eave</Text>
-			<Text id="actionMeetingHall">[M]eeting Hall</Text>
-			<Text id="actionUndock">[U]ndock</Text>
-
 			<Text id="descNormal">
 
 				The loud voices of a packed multitude bounce off every bulkhead and corridor in the station.
-				Old air scrubbers pump a thin, odorous breeze out of rusty vents. Discarded packets of 
+				Old air scrubbers pump a thin, odorous breeze out of rusty vents. Discarded packets of
 				Salmonite and Red Nebula beer huddle in the corner.
 
 				Welcome to Raisu Station!
+
+			</Text>
+		</Language>
+	</StationType>
+
+	<!-- Mission: Liberate Raisu station =======================================
+
+	EXTRA DATA
+
+	status:		Status of Raisu station
+					Nil						= Controlled by Centauri Warlords
+					'destroyed				= Destroyed
+					'destroyedByPlayer		= Destroyed by player
+					'liberated				= Liberated
+
+	targetID:				ID of ship to destroy (Arco Vaughn)
+	raidersSummoned:		Number of raiders summoned to station
+
+	======================================================================== -->
+
+	<MissionType UNID="&msRaisuStation;"
+			name=				"Liberate Raisu station"
+			attributes=			"commonwealth, special, deliveryMission"
+
+			level=				"1"
+
+			priority=			"10"
+			maxAppearing=		"1"
+			recordNonPlayer=	"true"
+			>
+
+		<Events>
+			<OnCreate>
+				(block (
+					(arcoVaughn (sysFindObject gSource "sN +arcoVaughn;"))
+					)
+					(switch
+						(not arcoVaughn)
+							(msnDestroy gSource)
+
+						(block Nil
+							(msnSetData gSource 'destID (objGetID aOwnerObj))
+
+							;	Remove Commonwealth ships
+							(objSetProperty aOwnerObj 'shipReinforcementEnabled Nil)
+							(enum (sysFindObject aOwnerObj "sO:docked;") theShip (objDestroy theShip))
+
+							;	Disable Commonwealth customs
+							(objSetEventHandler aOwnerObj &evCentauriOccupation;)
+
+							;	Add Centauri Raiders
+							(for i 1 (random 4 5)
+								(block (theShip)
+									(setq theShip (sysCreateShip &scCentauriRaider; aOwnerObj &svCentauriWarlords;))
+									(shpOrder theShip 'patrol aOwnerObj 10)
+									)
+								)
+
+							(msnSetData gSource 'targetID (objGetID arcoVaughn))
+							(msnRegisterForEvents gSource arcoVaughn)
+
+							;	Updates
+							(msnAddRecurringTimerEvent gSource 451 'OnTimer)
+							)
+						)
+					)
+			</OnCreate>
+
+			<OnAccepted>
+				(block (theItem launcherItem missileTypes bestType)
+					;	Give the player some appropriate missiles
+					(switch
+						;	If we don't have a launcher, give a missile rack
+						(not (setq launcherItem (@ (objGetItems gPlayerShip "lI -Disposable;") 0)))
+							(setq theItem (itmCreate &itDM1500MissileRack; 1))
+
+						;	Find all compatible missiles for this launcher
+						(not (setq missileTypes (itmGetTypes (cat "M +launchedBy:" (itmGetType launcherItem) ";"))))
+							(setq theItem (itmCreate &itDM1500MissileRack; 1))
+
+						;	Find a tracking missile of level 3 or less.
+						(setq bestType
+								(map missileTypes (list 'reduceMax 'original 'excludeNil) theType
+									(if (and (itmGetProperty theType 'tracking)
+											(leq (itmGetLevel theType) 3)
+											)
+										(itmGetLevel theType)
+										)
+									)
+								)
+							(setq theItem (itmCreate bestType (random 32 48)))
+
+						;	Otherwise, any missile of level 5 or less.
+						(setq bestType
+								(map missileTypes (list 'reduceMax 'original 'excludeNil) theType
+									(if (leq (itmGetLevel theType) 5)
+										(itmGetLevel theType)
+										)
+									)
+								)
+							(setq theItem (itmCreate bestType (random 32 48)))
+
+						;	Otherwise, default to a missile rack
+						(setq theItem (itmCreate &itDM1500MissileRack; 1))
+						)
+					(objAddItem gPlayerShip theItem)
+					(msnSetData gSource 'theItem theItem)
+					)
+			</OnAccepted>
+
+			<OnSetPlayerTarget>
+				(rpgSetTarget gSource aReason (objGetObjByID (msnGetData gSource 'targetID)))
+			</OnSetPlayerTarget>
+
+			<OnTimer>
+				(block (
+					(stationObj (objGetObjByID (msnGetProperty gSource 'ownerID)))
+					)
+					(switch
+						;	If not in Starton Eridani, then nothing to do
+						(!= (sysGetNode) (msnGetProperty gSource 'nodeID))
+							Nil
+
+						;	If we currently have raiders, then nothing to do
+						(sysFindObject stationObj "s +centauriWarlords; N:150")
+							Nil
+
+						;	If we've already summoned lots of raiders, then send Arco Vaughn
+						(gr (msnGetData gSource 'raidersSummoned) 20)
+							(block (arcoVaughn)
+								(setq arcoVaughn (sysFindObject stationObj "sN +arcoVaughn;"))
+								(if arcoVaughn
+									(objFireEvent arcoVaughn "OrderKillPlayer")
+									)
+								)
+
+						;	Otherwise summon some more raiders
+						(leq (random 1 100) 20)
+							(for i 1 (random 3 4)
+								(block (theShip)
+									(setq theShip
+										(sysCreateShip &scCentauriRaider;
+											(sysFindObject stationObj "GN -uncharted;")
+											&svCentauriWarlords;
+											)
+										)
+									(shpOrder theShip 'patrol stationObj 10)
+									(msnIncData gSource 'raidersSummoned)
+									)
+								)
+							)
+						)
+					)
+			</OnTimer>
+
+			<OnObjDestroyed>
+				(switch
+					(= (objGetID aObjDestroyed) (msnGetProperty gSource 'ownerID))
+						(block Nil
+							;	If the mission is still open we need to make it a non-player mission
+							(msnSetUnavailable gSource)
+							(msnFailure gSource {
+								destroyedByPlayer: (and gPlayerShip (= aOrderGiver gPlayerShip))
+								})
+							)
+
+					(= (objGetID aObjDestroyed) (msnGetData gSource 'targetID))
+						(block Nil
+							;	If the mission is still open we need to make it a non-player mission
+							(msnSetUnavailable gSource)
+							(msnSuccess gSource)
+							)
+					)
+			</OnObjDestroyed>
+
+			<OnCompleted>
+				(switch
+					(= aReason 'success)
+						(block (
+							(stationObj (objGetObjByID (msnGetProperty gSource 'ownerID)))
+							)
+							(msnSetData gSource 'status 'liberated)
+							(objSetProperty stationObj 'shipReinforcementEnabled True)
+							(objSetEventHandler stationObj Nil)
+							)
+
+					(and (= aReason 'failure) (@ gData 'destroyedByPlayer))
+						(msnSetData gSource 'status 'destroyedByPlayer)
+
+					(= aReason 'failure)
+						(msnSetData gSource 'status 'destroyed)
+					)
+			</OnCompleted>
+
+			<OnCanBrief>
+				(block (
+					(stationObj (objGetObjByID (msnGetProperty gSource 'ownerID)))
+					(centauriDestroyed (count (sysFindObject gPlayerShip "TK +centauriWarlords; +populated; -occupation; -uncharted;")))
+					)
+
+					(switch
+						;	If the player declined, then everyone is still in fear
+						(msnGetProperty gSource 'isDeclined)
+							(msnTranslate gSource 'descMissionHiding)
+
+						;	If there are Centauri raiders in range, then everyone is hinding
+						(sysFindObject stationObj "s +centauriWarlords; N:100;")
+							(msnTranslate gSource 'descMissionHiding)
+
+						;	If all stations have been destroyed, then the player gets the mission
+						(not (sysFindObject gPlayerShip "TA +centauriWarlords; +populated; -occupation; -uncharted;"))
+							Nil
+
+						;	Check the number of destroyed Centauri stations
+						(= centauriDestroyed 0)
+							(msnTranslate gSource 'descStationFearful0)
+
+						(= centauriDestroyed 1)
+							(msnTranslate gSource 'descStationFearful1)
+
+						(= centauriDestroyed 2)
+							(msnTranslate gSource 'descStationFearful2)
+
+						;	Otherwise player gets the mission
+						Nil
+						)
+					)
+			</OnCanBrief>
+
+			<OnDeliveryMissionCompleted>
+				{
+					desc: (msnTranslate gSource 'descHiding)
+					forceUndock: True
+					}
+			</OnDeliveryMissionCompleted>
+
+			<OnGlobalSystemStarted>
+				(block (raisuObj)
+					(switch
+						;	Only create in Starton Eridani
+						(!= (sysGetNode) 'SE)
+							Nil
+
+						;	Only create one
+						(msnFind "* +unid:&msRaisuStation;;")
+							Nil
+
+						(not (setq raisuObj (sysFindObject Nil "TAN +unid:&stRaisuStation;;")))
+							Nil
+
+						(msnCreate &msRaisuStation; raisuObj)
+						)
+					)
+			</OnGlobalSystemStarted>
+
+			<GetGlobalAchievements>
+				(block (theMission theStatus)
+					(if (and
+							(setq theMission (msnFind "P* +unid:&msRaisuStation;;"))
+							(setq theStatus (msnGetData theMission 'status))
+							)
+						(list
+							(list
+								(or (msnTranslate theMission (cat "achievement." theStatus))
+									(cat "ERROR: Raisu station status: " theStatus)
+									)
+								Nil
+								(typTranslate &unidCommonText; 'achievementsAndRegrets)
+								)
+							)
+						)
+					)
+			</GetGlobalAchievements>
+		</Events>
+
+
+		<Language>
+			<!-- Code Points -->
+
+			<Text id="Summary">
+				(cat
+					(msnTranslate gSource 'descSummary)
+					"\n\n"
+					(typTranslate &dsRPGMission; 'mission.rewardSummary {
+						systemName: (sysGetName)
+						payment: (fmtCurrency 'credit (msnGetData gSource 'reward))
+						})
+					)
+			</Text>
+
+			<Text id="AcceptReply">
+				(block (
+					(theItem (msnGetData gSource 'theItem))
+					)
+					(if (gr (itmGetCount theItem) 1)
+						(msnTranslate gSource 'descMissionAcceptPlural { itemName:(itmGetName theItem 'plural) })
+						(msnTranslate gSource 'descMissionAcceptSingular { itemName:(itmGetName theItem) })
+						)
+					)
+			</Text>
+
+			<Text id="InProgress">
+				(msnTranslate gSource 'descMissionHiding)
+			</Text>
+
+			<Text id="SuccessDebrief">
+				(if (= (plyGetGenome gPlayer) 'humanMale)
+					(msnTranslate gSource 'descMissionSuccessWhisper)
+					(msnTranslate gSource 'descMissionSuccessHug)
+					)
+			</Text>
+
+			<!-- Text -->
+
+			<Text id="Name">Kill Arco Vaughn</Text>
+			<Text id="descSummary">
+
+				Centauri warlords have taken over Raisu station. Help free the station by
+				killing the warlord Arco Vaughn.
 
 			</Text>
 			<Text id="descHiding">
@@ -509,7 +437,7 @@
 
 			</Text>
 
-			<Text id="descMissionIntro">
+			<Text id="Intro">
 
 				The station master stands at her console. She runs towards you tearfully:
 
@@ -520,7 +448,7 @@
 				"Arco Vaughn is the key. Kill him and the rest will leave us alone."
 
 			</Text>
-			<Text id="descMissionBriefing">
+			<Text id="Briefing">
 
 				"I can help you; I'm not afraid anymore. Arco Vaughn lives deep in the outer
 				belt&#x97;I can give you the coordinates. Kill him and we will all be free.
@@ -546,7 +474,7 @@
 				She hugs you quickly and runs off.
 
 			</Text>
-			<Text id="descMissionDecline">
+			<Text id="DeclineReply">
 
 				The station master stares at you in shock and then begins to weep.
 
@@ -586,6 +514,16 @@
 			<Text id="achievement.destroyed">Allowed Raisu station to be destroyed</Text>
 			<Text id="achievement.destroyedByPlayer">Destroyed Raisu station</Text>
 		</Language>
-	</StationType>
+	</MissionType>
+
+<!-- BEHAVIORS -->
+
+	<Type UNID="&evCentauriOccupation;">
+		<Events>
+			<GetCommonwealthCustomsStatus>
+				'disabled
+			</GetCommonwealthCustomsStatus>
+		</Events>
+	</Type>
 
 </TranscendenceModule>

--- a/TransCore/RaisuStation.xml
+++ b/TransCore/RaisuStation.xml
@@ -44,8 +44,9 @@
 							<Action id="actionMainHall" default="1">
 								(rpgMissionAssignment {
 									missionCriteria: "n +commonwealthHabitat;"
+									maxActive: 1
+									intervalPerType: (+ 5400 (* (objGetDestiny gSource) 10))
 									noMissionTextID: 'descNoMissions
-									maxPerStation: 1
 									})
 							</Action>
 
@@ -349,6 +350,24 @@
 						)
 					)
 			</GetGlobalAchievements>
+
+			<GetRumors>
+				(switch
+					(!= (msnGetProperty gSource 'nodeID) (sysGetNode))
+						Nil
+
+					(= (msnGetProperty gSource 'ownerID) (objGetID (@ gData 'stationObj)))
+						Nil
+
+					(msnGetProperty gSource 'isSuccess)
+						(rpgRumorAdd 'commonwealthHabitat (make 'sequence 5 8) 20)
+
+					(msnGetProperty gSource 'isFailure)
+						Nil
+
+					(rpgRumorAdd 'commonwealthHabitat (make 'sequence 1 4) 20)
+					)
+			</GetRumors>
 		</Events>
 
 
@@ -508,6 +527,43 @@
 
 				She beams a smile and hugs you again.
 
+			</Text>
+
+			<Text id="rumor.commonwealthHabitat.1">
+				"The warlords are annoying, but they don't mean much. The only one that bothers
+				me is Arco Vaughn. He's trouble. Someone ought to air him out before things get
+				out of hand, you know?"
+			</Text>
+			<Text id="rumor.commonwealthHabitat.2">
+				"It's sad about Raisu station, isn't it? If a corporate fuel station got taken
+				over by Centauri warlords they'd have Admiral Decker himself leading the
+				rescue. But no one cares about a poor, backwater station, I guess."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.3">
+				"If you're looking for Arco Vaughn, go to Raisu station: the station master
+				there will help you out. But first you gotta convince her that you're serious."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.4">
+				"If you need help against Arco Vaughn the station master at Raisu station will
+				help you. But you'll have to prove that you're serious. Take out a few Centauri
+				stations and you might convince her."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.5">
+				"Thank heavens that someone finally killed Arco Vaughn. Maybe now the warlords
+				will leave us alone."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.6">
+				"It's shame what Raisu station had to go through, isn't it? If a corporate
+				station had been occupied by warlords, they'd have sent Admiral Decker himself
+				to lead the rescue. But no one cares about a poor, backwater station, I guess."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.7">
+				"I hear that Arco Vaughn is finally dead. No one will mourn him. I really feel
+				for Erica and her team at Raisu&mdash;they went through hell."
+			</Text>
+			<Text id="rumor.commonwealthHabitat.8">
+				"We're all glad that Arco Vaughn is dead. I heard someone from Raisu station
+				finally had enough and decided to chase him down."
 			</Text>
 
 			<Text id="achievement.liberated">Liberated Raisu station</Text>

--- a/TransCore/RaisuStation.xml
+++ b/TransCore/RaisuStation.xml
@@ -20,7 +20,7 @@
 			regen=				"1"
 			ejectaType=			"&vtWreckEjecta;"
 
-			attributes=			"commonwealth, commonwealthCustoms, friendly, human, majorStation, occupation, populated, raisuStation"
+			attributes=			"commonwealth, commonwealthCustoms, friendly, human, majorStation, populated, raisuStation"
 			>
 
 		<ImageVariants>
@@ -824,6 +824,10 @@
 			<GetCommonwealthCustomsStatus>
 				'disabled
 			</GetCommonwealthCustomsStatus>
+
+			<GetTrafficStatus>
+				'deny
+			</GetTrafficStatus>
 		</Events>
 	</Type>
 

--- a/TransCore/RaisuStation.xml
+++ b/TransCore/RaisuStation.xml
@@ -266,7 +266,6 @@
 							(stationObj (objGetObjByID (msnGetProperty gSource 'ownerID)))
 							)
 							(msnSetData gSource 'status 'liberated)
-							(objSetProperty stationObj 'shipReinforcementEnabled True)
 							(objSetEventHandler stationObj Nil)
 							)
 
@@ -657,14 +656,7 @@
 
 						;	If we're attacked with something more powerful, then we
 						;	attack in force.
-
-						(block Nil
-							(shpCancelOrders gSource)
-							(shpOrder gSource 'attack gPlayerShip)
-							(objSetData gSource "behavior" 'killPlayer)
-
-							(objSendMessageTranslate gPlayerShip gSource 'msgWTF)
-							)
+						(objFireEvent gSource 'OrderKillPlayer)
 						)
 					)
 			</OnAttacked>
@@ -704,12 +696,7 @@
 									)
 
 								(if (gr (objGetDistance gPlayerShip homeObj) 300)
-									(block Nil
-										(shpCancelOrders gSource)
-										(shpOrder gSource 'patrol homeObj 5)
-										(objSetData gSource "behavior" Nil)
-										(objSetData gSource "warning" Nil)
-										)
+									(objFireEvent gSource 'OrderPatrolBase)
 									)
 								)
 
@@ -734,12 +721,7 @@
 									)
 
 								(if (gr (objGetDistance gPlayerShip homeObj) 300)
-									(block Nil
-										(shpCancelOrders gSource)
-										(shpOrder gSource 'patrol homeObj 5)
-										(objSetData gSource "behavior" Nil)
-										(objSetData gSource "warning" Nil)
-										)
+									(objFireEvent gSource 'OrderPatrolBase)
 									)
 								)
 						)
@@ -748,17 +730,10 @@
 
 			<OnDamage>
 				(block Nil
-
 					;	If the player damaged us, then attack
-					(if (and (eq aAttacker gPlayerShip)
-							(not (eq (objGetData gSource "behavior") 'killPlayer)))
-						(block Nil
-							(shpCancelOrders gSource)
-							(shpOrder gSource 'attack gPlayerShip)
-							(objSetData gSource "behavior" 'killPlayer)
-
-							(objSendMessageTranslate gPlayerShip gSource 'msgWTF)
-							)
+					(if (and (= aAttacker gPlayerShip)
+							(!= (objGetData gSource 'behavior) 'killPlayer))
+						(objFireEvent gSource 'OrderKillPlayer)
 						)
 
 					;	We always return full hit points
@@ -768,19 +743,27 @@
 
 			<OnObjDestroyed>
 				(if (eq aObjDestroyed gPlayerShip)
-					(block Nil
-						(shpCancelOrders gSource)
-						(shpOrder gSource 'patrol (objGetObjRefData gSource "home") 5)
-						(objSetData gSource "behavior" Nil)
-						)
+					(objFireEvent gSource 'OrderPatrolBase)
 					)
 			</OnObjDestroyed>
+
+			<OrderPatrolBase>
+				(block Nil
+					(shpCancelOrders gSource)
+					(shpOrder gSource 'patrol (objGetObjRefData gSource 'home) 5)
+					(objSetData gSource 'behavior Nil)
+					(objSetData gSource 'warning Nil)
+					)
+			</OrderPatrolBase>
 
 			<OrderKillPlayer>
 				(block Nil
 					(shpCancelOrders gSource)
 					(shpOrder gSource 'attack gPlayerShip)
 					(objSetData gSource "behavior" 'killPlayer)
+					(if (ls (objGetDistance gSource gPlayerShip) 120)
+						(objSendMessageTranslate gPlayerShip gSource 'msgWTF)
+						)
 					)
 			</OrderKillPlayer>
 		</Events>
@@ -830,6 +813,13 @@
 					(enum (sysFindObject gSource "sO:docked;") theShip (objDestroy theShip))
 					)
 			</OnEventHandlerInit>
+
+			<OnEventHandlerTerm>
+				(block Nil
+					(objSetProperty gSource 'shipReinforcementEnabled True)
+					(objSetProperty gSource 'shipConstructionEnabled Nil)
+					)
+			</OnEventHandlerTerm>
 
 			<GetCommonwealthCustomsStatus>
 				'disabled

--- a/TransCore/Sapiens.xml
+++ b/TransCore/Sapiens.xml
@@ -252,14 +252,14 @@
 					attributes: "commonwealthPub"
 					priority: 30
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}
 			</GetRumors>
 		</Events>
 
 		<Language>
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				You spend 5 credits and listen to a nuclear technician:
 
 				"I just got paid ten kilocreds to install a radiation room at

--- a/TransCore/Sapiens.xml
+++ b/TransCore/Sapiens.xml
@@ -251,7 +251,6 @@
 				{
 					attributes: "commonwealthPub"
 					priority: 30
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					onExitRumor: (lambda (theRumor) (objSetKnown (@ theRumor 'sourceObj)))
 					}

--- a/TransCore/SungSlavers.xml
+++ b/TransCore/SungSlavers.xml
@@ -1097,13 +1097,13 @@
 					attributes: "commonwealthPub"
 					priority: 41
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>
 		</Events>
 
 		<Language>
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				You spend 5 credits while listening to a drunk woman:
 
 				"My sister-in-law was abducted by those filthy Sung. We finally

--- a/TransCore/SungSlavers.xml
+++ b/TransCore/SungSlavers.xml
@@ -1096,7 +1096,6 @@
 				{
 					attributes: "commonwealthPub"
 					priority: 41
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>

--- a/TransCore/Xenophobes.xml
+++ b/TransCore/Xenophobes.xml
@@ -577,13 +577,13 @@
 					attributes: "commonwealthPub"
 					priority: 60
 					sourceObj: gSource
-					textID: 'rumor.pub
+					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>
 		</Events>
 
 		<Language>
-			<Text id="rumor.pub">
+			<Text id="rumor.commonwealthPub">
 				You spend 5 credits buying drinks for a mercenary. He talk about
 				his encounters with the Xenophobes:
 

--- a/TransCore/Xenophobes.xml
+++ b/TransCore/Xenophobes.xml
@@ -576,7 +576,6 @@
 				{
 					attributes: "commonwealthPub"
 					priority: 60
-					sourceObj: gSource
 					textID: 'rumor.commonwealthPub
 					}
 			</GetRumors>


### PR DESCRIPTION
Fix the GetGlobalRumor event, and use it for fixed rumors

Convert CommonwealthSlums to use new rumor system

Threat To Slums mission moved to separate file and Language elements updated

Convert Raisu Station to MissionType
* Adds `evCentauriOccupation` so occupation behavior can be enabled / disabled
* Adds `GetTrafficStatus` event to address [69868](https://ministry.kronosaur.com/record.hexm?id=69868)
* Requires Kronosaur/Mammoth#49 and Kronosaur/Mammoth#50