### PR TITLE
Minor bug fixes (i.e. Kronosaurus respawn bug)

### DIFF
--- a/TransCore/RPGCharacters.xml
+++ b/TransCore/RPGCharacters.xml
@@ -622,7 +622,7 @@
 				(typSetData charType 'screenData screenData)
 				))
 				
-			(setq rpgCharacterSetStatus (lambda (charType status)
+			(setq rpgCharacterSetStatus (lambda (charType newStatus)
 			
 				;	This function sets the status of the character. We support the following
 				;	values:
@@ -632,18 +632,18 @@
 				;	'dead: Character is permanently dead.
 
 				(block (
-					(status (typGetData charType 'status))
+					(oldStatus (typGetData charType 'status))
 					)
 					(switch				
 						;	If the character is permanently dead, then we can't 
 						;	change the status.
 
-						(= status 'dead)
+						(= oldStatus 'dead)
 							Nil
 
 						;	Set the status
 
-						(typSetData charType 'status status)
+						(typSetData charType 'status newStatus)
 						)
 					)
 				))

--- a/TransCore/Sapiens.xml
+++ b/TransCore/Sapiens.xml
@@ -329,12 +329,14 @@
 			
 			<OnProduceMissiles>
 				(if (not (objIsAbandoned gSource))
-					(block (theItems)
-						(setq theItems (objGetItems gSource "m +NAMILauncher;"))
-						(if (or (not theItems) (ls (itmGetCount (item theItems 0)) 16))
-							(block (newMissiles)
-								(setq newMissiles (random 10 40))
-								(objAddItem gSource (itmCreate &itXM300Missile; newMissiles))
+					(block (reapers)
+						
+						;	check how many reaper missiles we have and produce more if we're going to run out
+						
+						(setq reapers (@ (objGetItems gSource "m +unid:&itXM300Missile;;") 0))
+						(if (or (not reapers) (ls (itmGetCount reapers) 16))
+							(objAddItem gSource
+								(itmCreate &itXM300Missile; (random 10 40))		;	produce between 10 and 40 missiles
 								)
 							)
 						)


### PR DESCRIPTION
http://ministry.kronosaur.com/record.hexm?id=80407

A dead Kronosaurus respawned whenever player left and entered system. `rpgCharacterSetStatus` was doing nothing since there were two local variables with the same name `status`. Because of that, the Kronosaurus was not marked dead on destruction.

http://ministry.kronosaur.com/record.hexm?id=80057

Sapiens Compound produced too many Reaper missiles if carried two types of missiles (i.e. one other than the Reaper), likely due to how `&trStdTreasure;` could spawn various missile types. This was because it mistakenly counted a missile type other than the Reaper.
